### PR TITLE
Tropomi time fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- [issues/20] (https://github.com/podaac/l2ss-py/issues/20): Added .squeeze on cond.values, remove time dimension in indexers
+### Changed 
+### Deprecated 
+### Removed
+### Fixed
+- Fixed bug where temporal and spatial dimensions were not returning properly
+### Security
+
+## [Unreleased]
+### Added
 - [issues/11](https://github.com/podaac/l2ss-py/issues/11): Added .squeeze on lat in get_time_var method. Added GROUP_DELIM to the root group variables.
 ### Changed 
 - [issues/15](https://github.com/podaac/l2ss-py/issues/15): Changed the way groups are handled so that variables at the root of a file are not ignored. Groups now include the '/' level group

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated 
 ### Removed
 ### Fixed
+- Fixed bug where temporal and variable subsetting resulted in failure
 ### Security
 
 ## [1.0.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 	method. Added GROUP_DELIM to the root
 	group variables
 ### Changed 
-	recombine_groups method needs to have '/' as
-	a group
+	recombine_groups method needs gather all groups with all variables
+	including the root '/' group. nc_dataset is run through a loop to change
+	the variable names by adding a '__' to the front right before the walk method is called.
+        Groups list appends root level variables where the var_name.split returns a
+	['','Variable']. Groups list is changed so theses entries become ['',''] so that
+        there is a '/' group when variables are present.
 ### Deprecated 
 ### Removed
-	groups = set('/'.join(var_name.split(GROUP_DELIM)[:-1]
+	groups = set('/'.join(var_name.split(GROUP_DELIM)[:-1] line was removed.
+	Logic above assumes that all variables will be in a group
+	'/GROUP/Varible' when split becomes ['','GROUP','Variable'], the
+	last element is dropped and the two are joined to be '/GROUP'.
+	SNDR has variables in the root group so without adding a
+	GROUP_DELIM to the front of the root variable the var_name 'Varible'
+	becomes a blank list with split function applied.
 ### Fixed
 - Issues 10 and 15 are addressed and fixed.
 - Fixed bug where time variable wasnt found. Groups now include

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+### Changed 
+### Deprecated 
+### Removed 
+### Fixed 
+- Fixed bug where temporal and variable subsetting resulted in failure
+### Security
+
 ## [1.0.0]
 ### Added
 - PODAAC-3620: Added a script for running l2ss-py locally without Harmony

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,29 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- GESDISC: Added .squeeze on lat in get_time_var
-	method. Added GROUP_DELIM to the root
-	group variables
+- [issues/11](https://github.com/podaac/l2ss-py/issues/11): Added .squeeze on lat in get_time_var method. Added GROUP_DELIM to the root group variables.
 ### Changed 
-	recombine_groups method needs gather all groups with all variables
-	including the root '/' group. nc_dataset is run through a loop to change
-	the variable names by adding a '__' to the front right before the walk method is called.
-        Groups list appends root level variables where the var_name.split returns a
-	['','Variable']. Groups list is changed so theses entries become ['',''] so that
-        there is a '/' group when variables are present.
+- [issues/15](https://github.com/podaac/l2ss-py/issues/15): Changed the way groups are handled so that variables at the root of a file are not ignored. Groups now include the '/' level group
 ### Deprecated 
 ### Removed
-	groups = set('/'.join(var_name.split(GROUP_DELIM)[:-1] line was removed.
-	Logic above assumes that all variables will be in a group
-	'/GROUP/Varible' when split becomes ['','GROUP','Variable'], the
-	last element is dropped and the two are joined to be '/GROUP'.
-	SNDR has variables in the root group so without adding a
-	GROUP_DELIM to the front of the root variable the var_name 'Varible'
-	becomes a blank list with split function applied.
 ### Fixed
-- Issues 10 and 15 are addressed and fixed.
-- Fixed bug where time variable wasnt found. Groups now include
-	the '/' level group
 ### Security
 
 ## [1.0.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- GESDISC: Added .squeeze on lat in get_time_var metho
+- GESDISC: Added .squeeze on lat in get_time_var
+	method. Added GROUP_DELIM to the root
+	group variables
 ### Changed 
+	recombine_groups method needs to have '/' as
+	a group
 ### Deprecated 
-### Removed 
-### Fixed 
-- Fixed bug where time variable wasnt found
+### Removed
+	groups = set('/'.join(var_name.split(GROUP_DELIM)[:-1]
+### Fixed
+- Issues 10 and 15 are addressed and fixed.
+- Fixed bug where time variable wasnt found. Groups now include
+	the '/' level group
 ### Security
 
 ## [1.0.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- GESDISC: Added .squeeze on lat in get_time_var metho
 ### Changed 
 ### Deprecated 
 ### Removed 
 ### Fixed 
-- Fixed bug where temporal and variable subsetting resulted in failure
+- Fixed bug where time variable wasnt found
 ### Security
 
 ## [1.0.0]

--- a/podaac/subsetter/subset.py
+++ b/podaac/subsetter/subset.py
@@ -486,10 +486,10 @@ def get_time_variable_name(dataset, lat_var):
         return time_vars[0]
 
     for var_name in list(dataset.dims.keys()):
-        if "time" in var_name and dataset[var_name].squeeze().dims == lat_var.dims:
+        if "time" in var_name and dataset[var_name].squeeze().dims == lat_var.squeeze().dims:
             return var_name
     for var_name in list(dataset.data_vars.keys()):
-        if "time" in var_name and dataset[var_name].squeeze().dims == lat_var.dims:
+        if "time" in var_name and dataset[var_name].squeeze().dims == lat_var.squeeze().dims:
             return var_name
     raise ValueError('Unable to determine time variable')
 

--- a/podaac/subsetter/subset.py
+++ b/podaac/subsetter/subset.py
@@ -1031,9 +1031,13 @@ def subset(file_to_subset, bbox, output_file, variables=None,  # pylint: disable
             # Drop variables that aren't explicitly requested, except lat_var_name and
             # lon_var_name which are needed for subsetting
             variables = [variable.upper() for variable in variables]
-            vars_to_drop = [var_name for var_name, var in dataset.data_vars.items() if
-                            var_name.upper() not in variables and var_name not in lat_var_names and
-                            var_name not in lon_var_names]
+            vars_to_drop = [
+                var_name for var_name, var in dataset.data_vars.items()
+                if var_name.upper() not in variables
+                and var_name not in lat_var_names
+                and var_name not in lon_var_names
+                and var_name not in time_var_names
+            ]
             dataset = dataset.drop_vars(vars_to_drop)
 
         if bbox is not None:

--- a/podaac/subsetter/subset.py
+++ b/podaac/subsetter/subset.py
@@ -903,9 +903,9 @@ def recombine_grouped_datasets(datasets, output_file):
 
     for dataset in datasets:
         group_lst = []
-        for var_name in dataset.variables.keys(): #need logic if there is data in the top level not in a group
+        for var_name in dataset.variables.keys():  # need logic if there is data in the top level not in a group
             group_lst.append('/'.join(var_name.split(GROUP_DELIM)[:-1]))
-        group_lst = ['/' if group=='' else group for group in group_lst]
+        group_lst = ['/' if group == '' else group for group in group_lst]
         groups = set(group_lst)
         for group in groups:
             base_dataset.createGroup(group)

--- a/podaac/subsetter/subset.py
+++ b/podaac/subsetter/subset.py
@@ -865,6 +865,11 @@ def transform_grouped_dataset(nc_dataset, file_to_subset):
         for group_name in group_names:
             del group_node[group_name]
 
+    for var_name in list(nc_dataset.variables.keys()):
+        new_var_name = f'{GROUP_DELIM}{var_name}'
+        nc_dataset.variables[new_var_name] = nc_dataset.variables[var_name]
+        del nc_dataset.variables[var_name]
+
     walk(nc_dataset.groups, '')
 
     # Update the dimensions of the dataset in the root group
@@ -897,9 +902,11 @@ def recombine_grouped_datasets(datasets, output_file):
     base_dataset = nc.Dataset(output_file, mode='w')
 
     for dataset in datasets:
-        groups = set(
-            '/'.join(var_name.split(GROUP_DELIM)[:-1]) for var_name in dataset.variables.keys()
-        )
+        group_lst = []
+        for var_name in dataset.variables.keys(): #need logic if there is data in the top level not in a group
+            group_lst.append('/'.join(var_name.split(GROUP_DELIM)[:-1]))
+        group_lst = ['/' if group=='' else group for group in group_lst]
+        groups = set(group_lst)
         for group in groups:
             base_dataset.createGroup(group)
 

--- a/podaac/subsetter/xarray_enhancements.py
+++ b/podaac/subsetter/xarray_enhancements.py
@@ -65,10 +65,10 @@ def get_indexers_from_nd(cond, cut):
     dict
         Indexer dictionary for the provided condition.
     """
-    rows = np.any(cond.values, axis=1)
 
+    rows = np.any(cond.values.squeeze(), axis=1)
     if cut:
-        cols = np.any(cond.values, axis=0)
+        cols = np.any(cond.values.squeeze(), axis=0)
     else:
         cols = np.ones(len(cond.values[0]))
 
@@ -80,13 +80,13 @@ def get_indexers_from_nd(cond, cut):
     if not np.any(rows) | np.any(cols):
         logging.info("No data within the given bounding box.")
 
+    cond_list = [dim for dim in cond.dims if "time" not in dim ]
     indexers = {
-        cond.dims[0]: np.where(rows)[0],
-        cond.dims[1]: np.where(cols)[0]
+        cond_list[0]: np.where(rows)[0],
+        cond_list[1]: np.where(cols)[0]
     }
 
     return indexers
-
 
 def copy_empty_dataset(dataset):
     """
@@ -166,7 +166,6 @@ def where(dataset, cond, cut):
         indexers = get_indexers_from_1d(cond)
     else:
         indexers = get_indexers_from_nd(cond, cut)
-
     # If any of the indexer dimensions are empty, return an empty dataset
     if not all(len(value) > 0 for value in indexers.values()):
         return copy_empty_dataset(dataset)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@
 
 [tool.poetry]
 name = "l2ss-py"
-version = "1.1.0-alpha.0"
+version = "1.1.0-alpha.1"
 description = "L2 Subsetter Service"
 authors = ["podaac-tva <podaac-tva@jpl.nasa.gov>"]
 license = "Apache-2.0"

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -1192,8 +1192,9 @@ class TestSubsetter(unittest.TestCase):
             assert subset_file_size < original_file_size
 
     def test_get_time_squeeze(self):
-        
-
+        """test builtin squeeze method on the lat and time variables so 
+        when the two have the same shape with a time and delta time in
+        the tropomi product granuales the get_time_variable_name returns delta time as well"""
         file = '/tropomi/S5P_OFFL_L2__SO2____20200713T002730_20200713T020900_14239_01_020103_20200721T191355_subset.nc4'
         args = {
                 'decode_coords': False,

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -1244,8 +1244,8 @@ class TestSubsetter(unittest.TestCase):
             lat_var_name = subset.get_coord_variable_names(dataset)[0][0]
             time_var_name = subset.get_time_variable_name(dataset, dataset[lat_var_name])
             lat_dims = dataset[lat_var_name].squeeze().dims
-            time_var_name = dataset[time_var_name].squeeze().dims
-            assert (lat_dims == time_var_name)
+            time_dims = dataset[time_var_name].squeeze().dims
+            assert (lat_dims == time_dims)
 
     def test_temporal_merged_topex(self):
         """

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -1191,6 +1191,29 @@ class TestSubsetter(unittest.TestCase):
 
             assert subset_file_size < original_file_size
 
+    def test_get_time_squeeze(self):
+        
+
+        file = '/tropomi/S5P_OFFL_L2__SO2____20200713T002730_20200713T020900_14239_01_020103_20200721T191355_subset.nc4'
+        args = {
+                'decode_coords': False,
+                'mask_and_scale': False,
+                'decode_times': False
+            }
+        nc_dataset = nc.Dataset(self.test_data_dir+file, mode='r')
+        has_groups = bool(nc_dataset.groups)
+        if has_groups:
+            nc_dataset = subset.transform_grouped_dataset(nc_dataset, self.test_data_dir+file)
+        with xr.open_dataset(
+            xr.backends.NetCDF4DataStore(nc_dataset),
+            **args
+        ) as dataset:
+            lat_var_name = subset.get_coord_variable_names(dataset)[0][0]
+            time_var_name = subset.get_time_variable_name(dataset, dataset[lat_var_name])
+            lat_dims = dataset[lat_var_name].squeeze().dims
+            time_var_name = dataset[time_var_name].squeeze().dims
+            assert (lat_dims == time_var_name)
+
     def test_temporal_merged_topex(self):
         """
         Test that a temporal subset results in a granule that only

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -38,6 +38,7 @@ from shapely.geometry import Point
 
 from podaac.subsetter import subset
 from podaac.subsetter.subset import SERVICE_NAME
+from podaac.subsetter import xarray_enhancements as xre
 
 
 class TestSubsetter(unittest.TestCase):
@@ -366,7 +367,6 @@ class TestSubsetter(unittest.TestCase):
         """
         Run the L2 subsetter and compare the result to the equivelant
         legacy (Java) subsetter result.
-
         Parameters
         ----------
         java_files : list of strings
@@ -685,7 +685,6 @@ class TestSubsetter(unittest.TestCase):
     def test_get_spatial_bounds(self):
         """
         Test that the get_spatial_bounds function works as expected.
-
         The get_spatial_bounds function should return lat/lon min/max
         which is masked and scaled for both variables. The values
         should also be adjusted for -180,180/-90,90 coordinate types
@@ -1198,14 +1197,14 @@ class TestSubsetter(unittest.TestCase):
         shutil.copyfile(os.path.join(self.test_data_dir, 'SNDR', sndr_file_name),
                         os.path.join(self.subset_output_dir, sndr_file_name))
 
-        nc_dataset = nc.Dataset(os.path.join(self.test_data_dir, 'SNDR', sndr_file_name))
+        nc_dataset = nc.Dataset(os.path.join(self.subset_output_dir, sndr_file_name))
 
         args = {
                 'decode_coords': False,
                 'mask_and_scale': False,
                 'decode_times': False
             }
-        nc_dataset = subset.transform_grouped_dataset(nc_dataset, os.path.join(self.test_data_dir, 'SNDR', sndr_file_name))
+        nc_dataset = subset.transform_grouped_dataset(nc_dataset, os.path.join(self.subset_output_dir, sndr_file_name))
         with xr.open_dataset(
             xr.backends.NetCDF4DataStore(nc_dataset),
             **args
@@ -1229,14 +1228,14 @@ class TestSubsetter(unittest.TestCase):
         shutil.copyfile(os.path.join(self.test_data_dir, 'tropomi', tropomi_file_name),
                         os.path.join(self.subset_output_dir, tropomi_file_name))
 
-        nc_dataset = nc.Dataset(os.path.join(self.test_data_dir, 'tropomi', tropomi_file_name))
+        nc_dataset = nc.Dataset(os.path.join(self.subset_output_dir, tropomi_file_name))
 
         args = {
                 'decode_coords': False,
                 'mask_and_scale': False,
                 'decode_times': False
             }
-        nc_dataset = subset.transform_grouped_dataset(nc_dataset, os.path.join(self.test_data_dir, 'tropomi', tropomi_file_name))
+        nc_dataset = subset.transform_grouped_dataset(nc_dataset, os.path.join(self.subset_output_dir, tropomi_file_name))
         with xr.open_dataset(
             xr.backends.NetCDF4DataStore(nc_dataset),
             **args
@@ -1246,6 +1245,41 @@ class TestSubsetter(unittest.TestCase):
             lat_dims = dataset[lat_var_name].squeeze().dims
             time_dims = dataset[time_var_name].squeeze().dims
             assert (lat_dims == time_dims)
+
+    def test_get_indexers_nd(self):
+        """test that the time coordinate is not included in the indexers. Also test that the dimensions are the same for
+           a global box subset"""
+        tropomi_file_name = 'S5P_OFFL_L2__SO2____20200713T002730_20200713T020900_14239_01_020103_20200721T191355_subset.nc4'
+        shutil.copyfile(os.path.join(self.test_data_dir, 'tropomi', tropomi_file_name),
+                        os.path.join(self.subset_output_dir, tropomi_file_name))
+
+        nc_dataset = nc.Dataset(os.path.join(self.subset_output_dir, tropomi_file_name))
+
+        args = {
+                'decode_coords': False,
+                'mask_and_scale': False,
+                'decode_times': False
+            }
+        nc_dataset = subset.transform_grouped_dataset(nc_dataset, os.path.join(self.subset_output_dir, tropomi_file_name))
+        with xr.open_dataset(
+            xr.backends.NetCDF4DataStore(nc_dataset),
+            **args
+        ) as dataset:
+            lat_var_name = subset.get_coord_variable_names(dataset)[0][0]
+            lon_var_name = subset.get_coord_variable_names(dataset)[1][0]
+            oper = operator.and_
+
+            cond = oper(
+                (dataset[lon_var_name] >= -180),
+                (dataset[lon_var_name] <= 180)
+                ) & (dataset[lat_var_name] >= -90) & (dataset[lat_var_name] <= 90) & True
+
+            indexers = xre.get_indexers_from_nd(cond, True)
+            indexed_cond = cond.isel(**indexers)
+            indexed_ds = dataset.isel(**indexers)
+            new_dataset = indexed_ds.where(indexed_cond)
+            assert (('time' not in indexers.keys()) == True) #time can't be in the index
+            assert (new_dataset.dims == dataset.dims)
 
     def test_temporal_merged_topex(self):
         """

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -1191,7 +1191,7 @@ class TestSubsetter(unittest.TestCase):
 
             assert subset_file_size < original_file_size
 
-    def test_root_groop(self):
+    def test_root_group(self):
         """test that the GROUP_DELIM string, '__', is added to variables in the root group"""
 
         sndr_file_name = 'SNDR.SNPP.CRIMSS.20200118T0024.m06.g005.L2_CLIMCAPS_RET.std.v02_28.G.200314032326.nc'


### PR DESCRIPTION
Github Issue: #20
Subset_bbox calls xre.where and xre.where calls get_indexers_nd to get spatial box subset. Input time dimension had 1 value. Output has a much higher number depending on the box size, resulting in the 

_Summarize the ticket here_

Adjust get_indexers_from_nd method. Squeeze the cond.values for rows and cols since these need to be 1 dimensional arrays. Dims will have time, sometimes first and sometimes last. Put the dimensions in a list and drop the time variable.



### Overview of verification done

Tests that the dimensions of an input and output for a global box are the same. Also check that time is not a dimension returned in the get_indexers method. 

### Overview of integration done

_Explain how this change was integration tested. Provide screenshots or logs if appropriate. An example of this would be a local Harmony deployment._

## PR checklist:

* [ x] Linted
* [ x] Updated unit tests
* [x] Updated changelog
* [ x] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_