### PR TITLE
Fix bug that was including the time dimension in the spatial indexing…

### DIFF
--- a/podaac/subsetter/subset.py
+++ b/podaac/subsetter/subset.py
@@ -743,7 +743,7 @@ def subset_with_bbox(dataset, lat_var_names, lon_var_names, time_var_names, bbox
     return datasets
 
 
-def subset_with_shapefile(dataset, lat_var_name, lon_var_name, shapefile, cut):
+def subset_with_shapefile(dataset, lat_var_name, lon_var_name, shapefile, cut, time_var_names):
     """
     Subset an xarray Dataset using a shapefile
 
@@ -798,7 +798,7 @@ def subset_with_shapefile(dataset, lat_var_name, lon_var_name, shapefile, cut):
 
     in_shape_vec = np.vectorize(in_shape)
     boolean_mask = xr.apply_ufunc(in_shape_vec, dataset[lon_var_name], dataset[lat_var_name])
-    return xre.where(dataset, boolean_mask, cut)
+    return xre.where(dataset, boolean_mask, cut, time_var_names)
 
 
 def transform_grouped_dataset(nc_dataset, file_to_subset):
@@ -1060,7 +1060,7 @@ def subset(file_to_subset, bbox, output_file, variables=None,  # pylint: disable
             )
         elif shapefile:
             datasets = [
-                subset_with_shapefile(dataset, lat_var_names[0], lon_var_names[0], shapefile, cut)
+                subset_with_shapefile(dataset, lat_var_names[0], lon_var_names[0], shapefile, cut, time_var_names)
             ]
         else:
             raise ValueError('Either bbox or shapefile must be provided')

--- a/podaac/subsetter/subset.py
+++ b/podaac/subsetter/subset.py
@@ -735,15 +735,14 @@ def subset_with_bbox(dataset, lat_var_names, lon_var_names, time_var_names, bbox
             (group_dataset[lat_var_name] >= lat_bounds[0]) &
             (group_dataset[lat_var_name] <= lat_bounds[1]) &
             temporal_cond,
-            cut,
-            time_var_name
+            cut
         )
         datasets.append(group_dataset)
 
     return datasets
 
 
-def subset_with_shapefile(dataset, lat_var_name, lon_var_name, shapefile, cut, time_var_names):
+def subset_with_shapefile(dataset, lat_var_name, lon_var_name, shapefile, cut):
     """
     Subset an xarray Dataset using a shapefile
 
@@ -798,7 +797,7 @@ def subset_with_shapefile(dataset, lat_var_name, lon_var_name, shapefile, cut, t
 
     in_shape_vec = np.vectorize(in_shape)
     boolean_mask = xr.apply_ufunc(in_shape_vec, dataset[lon_var_name], dataset[lat_var_name])
-    return xre.where(dataset, boolean_mask, cut, time_var_names)
+    return xre.where(dataset, boolean_mask, cut)
 
 
 def transform_grouped_dataset(nc_dataset, file_to_subset):
@@ -1060,7 +1059,7 @@ def subset(file_to_subset, bbox, output_file, variables=None,  # pylint: disable
             )
         elif shapefile:
             datasets = [
-                subset_with_shapefile(dataset, lat_var_names[0], lon_var_names[0], shapefile, cut, time_var_names)
+                subset_with_shapefile(dataset, lat_var_names[0], lon_var_names[0], shapefile, cut)
             ]
         else:
             raise ValueError('Either bbox or shapefile must be provided')

--- a/podaac/subsetter/subset.py
+++ b/podaac/subsetter/subset.py
@@ -726,7 +726,6 @@ def subset_with_bbox(dataset, lat_var_names, lon_var_names, time_var_names, bbox
 
         # Calculate temporal conditions
         temporal_cond = build_temporal_cond(min_time, max_time, group_dataset, time_var_name)
-
         group_dataset = xre.where(
             group_dataset,
             oper(
@@ -736,7 +735,8 @@ def subset_with_bbox(dataset, lat_var_names, lon_var_names, time_var_names, bbox
             (group_dataset[lat_var_name] >= lat_bounds[0]) &
             (group_dataset[lat_var_name] <= lat_bounds[1]) &
             temporal_cond,
-            cut
+            cut,
+            time_var_name
         )
         datasets.append(group_dataset)
 

--- a/podaac/subsetter/xarray_enhancements.py
+++ b/podaac/subsetter/xarray_enhancements.py
@@ -65,10 +65,10 @@ def get_indexers_from_nd(cond, cut):
     dict
         Indexer dictionary for the provided condition.
     """
-    rows = np.any(cond.values, axis=1)
 
+    rows = np.any(cond.values.squeeze(), axis=1)
     if cut:
-        cols = np.any(cond.values, axis=0)
+        cols = np.any(cond.values.squeeze(), axis=0)
     else:
         cols = np.ones(len(cond.values[0]))
 
@@ -80,13 +80,13 @@ def get_indexers_from_nd(cond, cut):
     if not np.any(rows) | np.any(cols):
         logging.info("No data within the given bounding box.")
 
+    cond_list = [dim for dim in cond.dims if "time" not in dim ]
     indexers = {
-        cond.dims[0]: np.where(rows)[0],
-        cond.dims[1]: np.where(cols)[0]
+        cond_list[0]: np.where(rows)[0],
+        cond_list[1]: np.where(cols)[0]
     }
 
     return indexers
-
 
 def copy_empty_dataset(dataset):
     """
@@ -166,7 +166,6 @@ def where(dataset, cond, cut):
         indexers = get_indexers_from_1d(cond)
     else:
         indexers = get_indexers_from_nd(cond, cut)
-
     # If any of the indexer dimensions are empty, return an empty dataset
     if not all(len(value) > 0 for value in indexers.values()):
         return copy_empty_dataset(dataset)

--- a/podaac/subsetter/xarray_enhancements.py
+++ b/podaac/subsetter/xarray_enhancements.py
@@ -82,7 +82,7 @@ def get_indexers_from_nd(cond, cut):
 
     cond_shape_list = list(cond.shape)
     cond_list = list(cond.dims)
-    output = [idx for idx, element in enumerate(cond_shape_list) if cond_shape_list[idx]==1]
+    output = [idx for idx, element in enumerate(cond_shape_list) if cond_shape_list[idx] == 1]
     for i in output:
         cond_list.pop(i)
 
@@ -92,6 +92,7 @@ def get_indexers_from_nd(cond, cut):
     }
 
     return indexers
+
 
 def copy_empty_dataset(dataset):
     """

--- a/podaac/subsetter/xarray_enhancements.py
+++ b/podaac/subsetter/xarray_enhancements.py
@@ -80,7 +80,11 @@ def get_indexers_from_nd(cond, cut):
     if not np.any(rows) | np.any(cols):
         logging.info("No data within the given bounding box.")
 
-    cond_list = [dim for dim in cond.dims if 'time' not in dim]
+    cond_shape_list = list(cond.shape)
+    cond_list = list(cond.dims)
+    output = [idx for idx, element in enumerate(cond_shape_list) if cond_shape_list[idx]==1]
+    for i in output:
+        cond_list.pop(i)
 
     indexers = {
         cond_list[0]: np.where(rows)[0],
@@ -135,7 +139,7 @@ def cast_type(var, var_type):
     return var.astype(var_type)
 
 
-def where(dataset, cond, cut, time_var_names):
+def where(dataset, cond, cut):
     """
     Return a dataset which meets the given condition.
 
@@ -166,7 +170,7 @@ def where(dataset, cond, cut, time_var_names):
     if cond.values.ndim == 1:
         indexers = get_indexers_from_1d(cond)
     else:
-        indexers = get_indexers_from_nd(cond, cut, time_var_names)
+        indexers = get_indexers_from_nd(cond, cut)
     # If any of the indexer dimensions are empty, return an empty dataset
     if not all(len(value) > 0 for value in indexers.values()):
         return copy_empty_dataset(dataset)

--- a/podaac/subsetter/xarray_enhancements.py
+++ b/podaac/subsetter/xarray_enhancements.py
@@ -49,7 +49,7 @@ def get_indexers_from_1d(cond):
     return indexers
 
 
-def get_indexers_from_nd(cond, cut, time_var_name):
+def get_indexers_from_nd(cond, cut):
     """
     Get indexers from a dataset with more than 1 dimensions.
 
@@ -80,7 +80,8 @@ def get_indexers_from_nd(cond, cut, time_var_name):
     if not np.any(rows) | np.any(cols):
         logging.info("No data within the given bounding box.")
 
-    cond_list = [dim for dim in cond.dims if dim.split('__')[-1] not in time_var_name]
+    cond_list = [dim for dim in cond.dims if 'time' not in dim]
+
     indexers = {
         cond_list[0]: np.where(rows)[0],
         cond_list[1]: np.where(cols)[0]
@@ -134,7 +135,7 @@ def cast_type(var, var_type):
     return var.astype(var_type)
 
 
-def where(dataset, cond, cut, time_var_name):
+def where(dataset, cond, cut, time_var_names):
     """
     Return a dataset which meets the given condition.
 
@@ -165,7 +166,7 @@ def where(dataset, cond, cut, time_var_name):
     if cond.values.ndim == 1:
         indexers = get_indexers_from_1d(cond)
     else:
-        indexers = get_indexers_from_nd(cond, cut, time_var_name)
+        indexers = get_indexers_from_nd(cond, cut, time_var_names)
     # If any of the indexer dimensions are empty, return an empty dataset
     if not all(len(value) > 0 for value in indexers.values()):
         return copy_empty_dataset(dataset)

--- a/podaac/subsetter/xarray_enhancements.py
+++ b/podaac/subsetter/xarray_enhancements.py
@@ -49,7 +49,7 @@ def get_indexers_from_1d(cond):
     return indexers
 
 
-def get_indexers_from_nd(cond, cut):
+def get_indexers_from_nd(cond, cut, time_var_name):
     """
     Get indexers from a dataset with more than 1 dimensions.
 
@@ -80,7 +80,7 @@ def get_indexers_from_nd(cond, cut):
     if not np.any(rows) | np.any(cols):
         logging.info("No data within the given bounding box.")
 
-    cond_list = [dim for dim in cond.dims if "time" not in dim ]
+    cond_list = [dim for dim in cond.dims if dim.split('__')[-1] not in time_var_name]
     indexers = {
         cond_list[0]: np.where(rows)[0],
         cond_list[1]: np.where(cols)[0]
@@ -134,7 +134,7 @@ def cast_type(var, var_type):
     return var.astype(var_type)
 
 
-def where(dataset, cond, cut):
+def where(dataset, cond, cut, time_var_name):
     """
     Return a dataset which meets the given condition.
 
@@ -165,7 +165,7 @@ def where(dataset, cond, cut):
     if cond.values.ndim == 1:
         indexers = get_indexers_from_1d(cond)
     else:
-        indexers = get_indexers_from_nd(cond, cut)
+        indexers = get_indexers_from_nd(cond, cut, time_var_name)
     # If any of the indexer dimensions are empty, return an empty dataset
     if not all(len(value) > 0 for value in indexers.values()):
         return copy_empty_dataset(dataset)

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -1267,6 +1267,7 @@ class TestSubsetter(unittest.TestCase):
         ) as dataset:
             lat_var_name = subset.get_coord_variable_names(dataset)[0][0]
             lon_var_name = subset.get_coord_variable_names(dataset)[1][0]
+            time_var_name = subset.get_time_variable_name(dataset, dataset[lat_var_name])
             oper = operator.and_
 
             cond = oper(
@@ -1274,11 +1275,11 @@ class TestSubsetter(unittest.TestCase):
                 (dataset[lon_var_name] <= 180)
                 ) & (dataset[lat_var_name] >= -90) & (dataset[lat_var_name] <= 90) & True
 
-            indexers = xre.get_indexers_from_nd(cond, True)
+            indexers = xre.get_indexers_from_nd(cond, True, time_var_name)
             indexed_cond = cond.isel(**indexers)
             indexed_ds = dataset.isel(**indexers)
             new_dataset = indexed_ds.where(indexed_cond)
-            assert (('time' not in indexers.keys()) == True) #time can't be in the index
+            assert ((time_var_name not in indexers.keys()) == True) #time can't be in the index
             assert (new_dataset.dims == dataset.dims)
 
     def test_temporal_merged_topex(self):

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -1275,10 +1275,11 @@ class TestSubsetter(unittest.TestCase):
                 (dataset[lon_var_name] <= 180)
                 ) & (dataset[lat_var_name] >= -90) & (dataset[lat_var_name] <= 90) & True
 
-            indexers = xre.get_indexers_from_nd(cond, True, time_var_name)
+            indexers = xre.get_indexers_from_nd(cond, True)
             indexed_cond = cond.isel(**indexers)
             indexed_ds = dataset.isel(**indexers)
             new_dataset = indexed_ds.where(indexed_cond)
+
             assert ((time_var_name not in indexers.keys()) == True) #time can't be in the index
             assert (new_dataset.dims == dataset.dims)
 

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -38,6 +38,7 @@ from shapely.geometry import Point
 
 from podaac.subsetter import subset
 from podaac.subsetter.subset import SERVICE_NAME
+from podaac.subsetter import xarray_enhancements as xre
 
 
 class TestSubsetter(unittest.TestCase):
@@ -366,7 +367,6 @@ class TestSubsetter(unittest.TestCase):
         """
         Run the L2 subsetter and compare the result to the equivelant
         legacy (Java) subsetter result.
-
         Parameters
         ----------
         java_files : list of strings
@@ -685,7 +685,6 @@ class TestSubsetter(unittest.TestCase):
     def test_get_spatial_bounds(self):
         """
         Test that the get_spatial_bounds function works as expected.
-
         The get_spatial_bounds function should return lat/lon min/max
         which is masked and scaled for both variables. The values
         should also be adjusted for -180,180/-90,90 coordinate types
@@ -1198,14 +1197,14 @@ class TestSubsetter(unittest.TestCase):
         shutil.copyfile(os.path.join(self.test_data_dir, 'SNDR', sndr_file_name),
                         os.path.join(self.subset_output_dir, sndr_file_name))
 
-        nc_dataset = nc.Dataset(os.path.join(self.test_data_dir, 'SNDR', sndr_file_name))
+        nc_dataset = nc.Dataset(os.path.join(self.subset_output_dir, sndr_file_name))
 
         args = {
                 'decode_coords': False,
                 'mask_and_scale': False,
                 'decode_times': False
             }
-        nc_dataset = subset.transform_grouped_dataset(nc_dataset, os.path.join(self.test_data_dir, 'SNDR', sndr_file_name))
+        nc_dataset = subset.transform_grouped_dataset(nc_dataset, os.path.join(self.subset_output_dir, sndr_file_name))
         with xr.open_dataset(
             xr.backends.NetCDF4DataStore(nc_dataset),
             **args
@@ -1229,14 +1228,14 @@ class TestSubsetter(unittest.TestCase):
         shutil.copyfile(os.path.join(self.test_data_dir, 'tropomi', tropomi_file_name),
                         os.path.join(self.subset_output_dir, tropomi_file_name))
 
-        nc_dataset = nc.Dataset(os.path.join(self.test_data_dir, 'tropomi', tropomi_file_name))
+        nc_dataset = nc.Dataset(os.path.join(self.subset_output_dir, tropomi_file_name))
 
         args = {
                 'decode_coords': False,
                 'mask_and_scale': False,
                 'decode_times': False
             }
-        nc_dataset = subset.transform_grouped_dataset(nc_dataset, os.path.join(self.test_data_dir, 'tropomi', tropomi_file_name))
+        nc_dataset = subset.transform_grouped_dataset(nc_dataset, os.path.join(self.subset_output_dir, tropomi_file_name))
         with xr.open_dataset(
             xr.backends.NetCDF4DataStore(nc_dataset),
             **args
@@ -1246,6 +1245,41 @@ class TestSubsetter(unittest.TestCase):
             lat_dims = dataset[lat_var_name].squeeze().dims
             time_dims = dataset[time_var_name].squeeze().dims
             assert (lat_dims == time_dims)
+
+    def test_get_indexers_nd(self):
+        """test that the time coordinate is not included in the indexers. Also test that the dimensions are the same for
+           a global box subset"""
+        tropomi_file_name = 'S5P_OFFL_L2__SO2____20200713T002730_20200713T020900_14239_01_020103_20200721T191355_subset.nc4'
+        shutil.copyfile(os.path.join(self.test_data_dir, 'tropomi', tropomi_file_name),
+                        os.path.join(self.subset_output_dir, tropomi_file_name))
+
+        nc_dataset = nc.Dataset(os.path.join(self.subset_output_dir, tropomi_file_name))
+
+        args = {
+                'decode_coords': False,
+                'mask_and_scale': False,
+                'decode_times': False
+            }
+        nc_dataset = subset.transform_grouped_dataset(nc_dataset, os.path.join(self.subset_output_dir, tropomi_file_name))
+        with xr.open_dataset(
+            xr.backends.NetCDF4DataStore(nc_dataset),
+            **args
+        ) as dataset:
+            lat_var_name = subset.get_coord_variable_names(dataset)[0][0]
+            lon_var_name = subset.get_coord_variable_names(dataset)[1][0]
+            oper = operator.and_
+
+            cond = oper(
+                (dataset[lon_var_name] >= -180),
+                (dataset[lon_var_name] <= 180)
+                ) & (dataset[lat_var_name] >= -90) & (dataset[lat_var_name] <= 90) & True
+
+            indexers = xre.get_indexers_from_nd(cond, True)
+            indexed_cond = cond.isel(**indexers)
+            indexed_ds = dataset.isel(**indexers)
+            new_dataset = indexed_ds.where(indexed_cond)
+            assert (('time' not in indexers.keys()) == True) #time can't be in the index
+            assert (new_dataset.dims == dataset.dims)
 
     def test_temporal_merged_topex(self):
         """


### PR DESCRIPTION
… get_indexers_nd method

Github Issue: #20

### Description

Subset_bbox calls xre.where and xre.where calls get_indexers_nd to get spatial box subset. Input time dimension had 1 value. Output has a much higher number depending on the box size, resulting in the file becoming massive.

### Overview of work done

Adjust get_indexers_from_nd method. Squeeze the cond.values for rows and cols since these need to be 1 dimensional arrays. Dims will have time, sometimes first and sometimes last. Put the dimensions in a list and drop the time variable.

### Overview of verification done

Unit test written to confirm the dimensions of tropomi file weren't altered for a global box. Confirm that subset_box doesn't index to time.

### Overview of integration done

_Explain how this change was integration tested. Provide screenshots or logs if appropriate. An example of this would be a local Harmony deployment._

## PR checklist:

* [x ] Linted
* [ x] Updated unit tests
* [ x] Updated changelog
* [ x] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_