### PR TITLE
Feature/issues-32: Allow variable subsetting for variables in a group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated 
 ### Removed
 ### Fixed
+- [issues/32](https://github.com/podaac/l2ss-py/issues/32): Fixed bug where input variables arguments have a '/' character
 - [issues/20](https://github.com/podaac/l2ss-py/issues/20): Fixed bug where spatial indexing was including extra dimensions causing output file to drastically increase in size
 - [issues/10](https://github.com/podaac/l2ss-py/issues/10): Fixed bug where variable dimensions are assumed to be the same across all variables in a group in recombine_group_dataset method. When variables are written out, shape must match.
 - [issues/28](https://github.com/podaac/l2ss-py/issues/28): Fixed bug where variable dtype would be type object, the code would raise exception. Fix adds logic to handle type object 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated 
 ### Removed
 ### Fixed
-- [issues/32](https://github.com/podaac/l2ss-py/issues/32): Fixed bug where input variables arguments have a '/' character
+- [issues/32](https://github.com/podaac/l2ss-py/issues/32): Fixed bug when given variables to subset that have a '/' character in the variable name, they would not appear in the output.
 - [issues/20](https://github.com/podaac/l2ss-py/issues/20): Fixed bug where spatial indexing was including extra dimensions causing output file to drastically increase in size
 - [issues/10](https://github.com/podaac/l2ss-py/issues/10): Fixed bug where variable dimensions are assumed to be the same across all variables in a group in recombine_group_dataset method. When variables are written out, shape must match.
 - [issues/28](https://github.com/podaac/l2ss-py/issues/28): Fixed bug where variable dtype would be type object, the code would raise exception. Fix adds logic to handle type object 

--- a/podaac/subsetter/subset.py
+++ b/podaac/subsetter/subset.py
@@ -1015,6 +1015,9 @@ def subset(file_to_subset, bbox, output_file, variables=None,  # pylint: disable
     if has_groups:
         nc_dataset = transform_grouped_dataset(nc_dataset, file_to_subset)
 
+    if variables:
+        variables = [x.replace('/', '__') for x in variables]
+
     args = {
         'decode_coords': False,
         'mask_and_scale': False,

--- a/podaac/subsetter/subset.py
+++ b/podaac/subsetter/subset.py
@@ -1016,7 +1016,7 @@ def subset(file_to_subset, bbox, output_file, variables=None,  # pylint: disable
         nc_dataset = transform_grouped_dataset(nc_dataset, file_to_subset)
 
     if variables:
-        variables = [x.replace('/', '__') for x in variables]
+        variables = [x.replace('/', GROUP_DELIM) for x in variables]
 
     args = {
         'decode_coords': False,

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -805,6 +805,30 @@ class TestSubsetter(unittest.TestCase):
             in_shape_vec = np.vectorize(in_shape)
             in_shape_vec(result_dataset.lon, result_dataset.lat)
 
+    def test_variable_subset_oco2(self):
+        """
+        variable subsets for groups and root group using a '/'
+        """
+
+        oco2_file_name = 'oco2_LtCO2_190201_B10206Ar_200729175909s.nc4'
+        output_file_name = 'oco2_test_out.nc'
+        shutil.copyfile(os.path.join(self.test_data_dir, 'OCO2', oco2_file_name),
+                        os.path.join(self.subset_output_dir, oco2_file_name))
+        bbox = np.array(((-180,180),(-90.0,90)))
+        variables = ['/xco2','/xco2_quality_flag','/Retrieval/water_height','/sounding_id']
+        subset.subset(
+            file_to_subset=join(self.test_data_dir, 'OCO2',oco2_file_name),
+            bbox=bbox,
+            variables=variables,
+            output_file=join(self.subset_output_dir, output_file_name),
+        )
+        
+        out_nc = nc.Dataset(join(self.subset_output_dir, output_file_name))
+        var_listout = list(out_nc.groups['Retrieval'].variables.keys())
+        assert ('water_height' in var_listout)
+        #assert (in_nc.variables['xco2_quality_flag'] == out_nc.variables['xco2_quality_flag'])
+        #assert (in_nc.groups['Retrieval'].variables)
+
     def test_transform_grouped_dataset(self):
         """
         Test that the transformation function results in a correctly


### PR DESCRIPTION
Github Issue: #32 
### Description

Fix bug to allow variable subsetting with groups be done with '/' characters

### Overview of work done

Replace input '/' characters with '__' characters

### Overview of verification done

Wrote test to check if variable in a group for a variable subset made it through the subsetter process.

### Overview of integration done

_Explain how this change was integration tested. Provide screenshots or logs if appropriate. An example of this would be a local Harmony deployment._

## PR checklist:

* [ x] Linted
* [ x] Updated unit tests
* [ x] Updated changelog
* [ ] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_