### PR TITLE
feature/issue-34: Support for var subsetting when vars are in a different group as coordinate vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated 
 ### Removed
 ### Fixed
+- [issues/34](https://github.com/podaac/l2ss-py/issues/34): Fixed bug that did not allow variable subsetting in OCO3 files. Fix includes adding the variable list in subset_bbox method 
 ### Security
 
 ## [1.2.0]

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -853,6 +853,30 @@ class TestSubsetter(unittest.TestCase):
         assert ('SIF_Relative_SDev_757nm' in var_listout)
         assert ('temperature_skin' in var_listout)
 
+    def test_variable_subset_s6(self):
+        """
+        multiple variable subset of variables in different groups in oco3
+        """
+
+        s6_file_name = 'S6A_P4_2__LR_STD__ST_002_140_20201207T011501_20201207T013023_F00.nc'
+        output_file_name = 's6_test_out.nc'
+        shutil.copyfile(os.path.join(self.test_data_dir, 'sentinel_6', s6_file_name),
+                        os.path.join(self.subset_output_dir, s6_file_name))
+        bbox = np.array(((-180,180),(-90.0,90)))
+        variables = ['/data_01/ku/range_ocean_mle3_rms', '/data_20/ku/range_ocean']
+        subset.subset(
+            file_to_subset=join(self.test_data_dir, 'sentinel_6',s6_file_name),
+            bbox=bbox,
+            variables=variables,
+            output_file=join(self.subset_output_dir, output_file_name),
+        )
+        
+        out_nc = nc.Dataset(join(self.subset_output_dir, output_file_name))
+        var_listout =list(out_nc.groups['data_01'].groups['ku'].variables.keys())
+        var_listout.extend(list(out_nc.groups['data_20'].groups['ku'].variables.keys()))
+        assert ('range_ocean_mle3_rms' in var_listout)
+        assert ('range_ocean' in var_listout)
+
 
     def test_transform_grouped_dataset(self):
         """

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -826,8 +826,33 @@ class TestSubsetter(unittest.TestCase):
         out_nc = nc.Dataset(join(self.subset_output_dir, output_file_name))
         var_listout = list(out_nc.groups['Retrieval'].variables.keys())
         assert ('water_height' in var_listout)
-        #assert (in_nc.variables['xco2_quality_flag'] == out_nc.variables['xco2_quality_flag'])
-        #assert (in_nc.groups['Retrieval'].variables)
+
+    def test_variable_subset_oco3(self):
+        """
+        multiple variable subset of variables in different groups in oco3
+        """
+
+        oco3_file_name = 'oco3_LtSIF_200226_B10206r_200709053505s.nc4'
+        output_file_name = 'oco3_test_out.nc'
+        shutil.copyfile(os.path.join(self.test_data_dir, 'OCO3/OCO3_L2_LITE_SIF.EarlyR', oco3_file_name),
+                        os.path.join(self.subset_output_dir, oco3_file_name))
+        bbox = np.array(((-180,180),(-90.0,90)))
+        variables = ['/Science/IGBP_index', '/Offset/SIF_Relative_SDev_757nm','/Meteo/temperature_skin']
+        subset.subset(
+            file_to_subset=join(self.test_data_dir, 'OCO3/OCO3_L2_LITE_SIF.EarlyR',oco3_file_name),
+            bbox=bbox,
+            variables=variables,
+            output_file=join(self.subset_output_dir, output_file_name),
+        )
+        
+        out_nc = nc.Dataset(join(self.subset_output_dir, output_file_name))
+        var_listout =list(out_nc.groups['Science'].variables.keys())
+        var_listout.extend(list(out_nc.groups['Offset'].variables.keys()))
+        var_listout.extend(list(out_nc.groups['Meteo'].variables.keys()))
+        assert ('IGBP_index' in var_listout)
+        assert ('SIF_Relative_SDev_757nm' in var_listout)
+        assert ('temperature_skin' in var_listout)
+
 
     def test_transform_grouped_dataset(self):
         """


### PR DESCRIPTION
Github Issue: #34 
### Description

Variable subsetting in OCO3 would not work for variables in a different group as the latitude variable

### Overview of work done

Added variable list as an argument in subset_bbox and extend the group list if the variables are present. 

### Overview of verification done

Test 3 variables in 3 different groups for OCO3 files.

### Overview of integration done

_Explain how this change was integration tested. Provide screenshots or logs if appropriate. An example of this would be a local Harmony deployment._

## PR checklist:

* [ x] Linted
* [ x] Updated unit tests
* [ x] Updated changelog
* [ ] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_