### PR TITLE
Issue-36 Empty datasets retain dimensions of the original

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 ### Changed 
+- [issues/36](https://github.com/podaac/l2ss-py/issues/36): Empty datasets will now maintain attributes, variables, and dimensions where each variable contains a single data point where the value is masked.
 ### Deprecated 
 ### Removed
 ### Fixed

--- a/podaac/subsetter/xarray_enhancements.py
+++ b/podaac/subsetter/xarray_enhancements.py
@@ -20,6 +20,7 @@ for this specific use-case.
 """
 
 import logging
+
 import numpy as np
 import xarray as xr
 
@@ -112,13 +113,15 @@ def copy_empty_dataset(dataset):
     xarray.Dataset
         The new dataset which has no data.
     """
-    empty_dataset = xr.Dataset()
-    for variable_name, variable in dataset.data_vars.items():
-        empty_dataset[variable_name] = []
-        empty_dataset[variable_name].attrs = variable.attrs
-    # Copy global metadata
-    empty_dataset.attrs = dataset.attrs
-    return empty_dataset
+    # Create a dict object where each key is a variable in the dataset and the value is an
+    # array initialized to the fill value for that variable or NaN if there is no fill value
+    # attribute for the variable
+    empty_data = {k: np.full(v.shape, dataset.variables[k].attrs.get('_FillValue', np.nan)) for k, v in
+                  dataset.items()}
+
+    # Create a copy of the dataset filled with the empty data. Then select the first index along each
+    # dimension and return the result
+    return dataset.copy(data=empty_data).isel({dim: 0 for dim in dataset.dims})
 
 
 def cast_type(var, var_type):

--- a/podaac/subsetter/xarray_enhancements.py
+++ b/podaac/subsetter/xarray_enhancements.py
@@ -121,7 +121,7 @@ def copy_empty_dataset(dataset):
 
     # Create a copy of the dataset filled with the empty data. Then select the first index along each
     # dimension and return the result
-    return dataset.copy(data=empty_data).isel({dim: 0 for dim in dataset.dims})
+    return dataset.copy(data=empty_data).isel({dim: slice(0, 1, 1) for dim in dataset.dims})
 
 
 def cast_type(var, var_type):

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -304,6 +304,12 @@ class TestSubsetter(unittest.TestCase):
                 bbox=bbox,
                 output_file=join(self.subset_output_dir, output_file)
             )
+            test_input_dataset = xr.open_dataset(
+                join(self.test_data_dir, file),
+                decode_times=False,
+                decode_coords=False,
+                mask_and_scale=False
+            )
             empty_dataset = xr.open_dataset(
                 join(self.subset_output_dir, output_file),
                 decode_times=False,
@@ -314,6 +320,9 @@ class TestSubsetter(unittest.TestCase):
             # Ensure all variables are present but empty.
             for variable_name, variable in empty_dataset.data_vars.items():
                 assert not variable.data
+
+            assert test_input_dataset.dims.keys() == empty_dataset.dims.keys()
+
 
     def test_bbox_conversion(self):
         """

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -319,7 +319,7 @@ class TestSubsetter(unittest.TestCase):
 
             # Ensure all variables are present but empty.
             for variable_name, variable in empty_dataset.data_vars.items():
-                assert not variable.data
+                assert np.all(variable.data == variable.attrs.get('_FillValue', np.nan) or np.isnan(variable.data))
 
             assert test_input_dataset.dims.keys() == empty_dataset.dims.keys()
 


### PR DESCRIPTION
Github Issue: #36

### Description

When a subset results in no actual data being selected, l2ss-py returns an empty dataset. Previously this empty dataset did not retain dimensions of the original. This change now has empty datasets retain dimensions.

### Overview of work done

Use dataset.copy to copy the original dataset and then remove all of the data by using the dataset's fill value and selecting the first index along each dimension to result in one single masked-out value per value.

### Overview of verification done

Updated the unit test to check that dimensions remain

### Overview of integration done

TBD

## PR checklist:

* [x] Linted
* [x] Updated unit tests
* [x] Updated changelog
* [ ] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_