### PR TITLE
Fixed bug in test case

### DIFF
--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -839,7 +839,7 @@ class TestSubsetter(unittest.TestCase):
         bbox = np.array(((-180,180),(-90.0,90)))
         variables = ['/Science/IGBP_index', '/Offset/SIF_Relative_SDev_757nm','/Meteo/temperature_skin']
         subset.subset(
-            file_to_subset=join(self.test_data_dir, 'OCO3/OCO3_L2_LITE_SIF.EarlyR',oco3_file_name),
+            file_to_subset=join(self.subset_output_dir, oco3_file_name),
             bbox=bbox,
             variables=variables,
             output_file=join(self.subset_output_dir, output_file_name),
@@ -865,7 +865,7 @@ class TestSubsetter(unittest.TestCase):
         bbox = np.array(((-180,180),(-90.0,90)))
         variables = ['/data_01/ku/range_ocean_mle3_rms', '/data_20/ku/range_ocean']
         subset.subset(
-            file_to_subset=join(self.test_data_dir, 'sentinel_6',s6_file_name),
+            file_to_subset=join(self.subset_output_dir, s6_file_name),
             bbox=bbox,
             variables=variables,
             output_file=join(self.subset_output_dir, output_file_name),


### PR DESCRIPTION
Github Issue: N/A

### Description

Fixed bug in test case causing tests to fail.

### Overview of work done

In order to support groups, we had to to use the netCDF4 python library which will modify the input file when transformations are made.  This means any test case using a test granule with groups should copy the file before running any subset operations. 

The PR https://github.com/podaac/l2ss-py/pull/35 made the mistake of using the test granule instead of the copied granule, which caused the test granule to be modified. The modified granule was then committed to the develop branch during the versioning stage of the build pipeline. This explains why the test passed the build pipeline but failed after that, and why it passed when I ran it locally but failed after pulling the latest. 

Fixed the copying issue and replaced the S6 granule with the previous version.

### Overview of verification done

Ran the unit tests locally... twice.

### Overview of integration done

N/A

## PR checklist:

* [] Linted
* [X] Updated unit tests
* [ ] Updated changelog
* [ ] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_