### PR TITLE
feature/issue-50: Empty subset for grouped dataset results in error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- [issues/50](https://github.com/podaac/l2ss-py/issues/50): Spatial bounds are computed correctly for grouped empty subset operations
 ### Changed 
 ### Deprecated 
 ### Removed

--- a/podaac/subsetter/subset.py
+++ b/podaac/subsetter/subset.py
@@ -1131,6 +1131,10 @@ def subset(file_to_subset, bbox, output_file, variables=None,  # pylint: disable
 
         if has_groups:
             recombine_grouped_datasets(datasets, output_file)
+            # Check if the spatial bounds are all 'None'. This means the
+            # subset result is empty.
+            if any(bound is None for bound in spatial_bounds):
+                return None
             return np.array([[
                 min(lon[0][0][0] for lon in zip(spatial_bounds)),
                 max(lon[0][0][1] for lon in zip(spatial_bounds))

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -1580,3 +1580,23 @@ class TestSubsetter(unittest.TestCase):
         )
 
         assert ds.time.dims != ds.latitude.dims
+
+    def test_grouped_empty_subset(self):
+        """
+        Test that an empty subset of a grouped dataset returns 'None'
+        spatial bounds.
+        """
+        bbox = np.array(((-10, 10), (-10, 10)))
+        file = 'S6A_P4_2__LR_STD__ST_002_140_20201207T011501_20201207T013023_F00.nc'
+        output_file = "{}_{}".format(self._testMethodName, file)
+
+        shutil.copyfile(os.path.join(self.test_data_dir, 'sentinel_6', file),
+                        os.path.join(self.subset_output_dir, file))
+
+        spatial_bounds = subset.subset(
+            file_to_subset=join(self.subset_output_dir, file),
+            bbox=bbox,
+            output_file=join(self.subset_output_dir, output_file)
+        )
+
+        assert spatial_bounds is None


### PR DESCRIPTION
Github Issue: #50

### Description

An empty subset of a grouped dataset causes issues when the spatial bounds of the result are being calculated.

### Overview of work done

Updated the above scenario to check for 'None' values in the spatial bounds, meaning there was no data in the subset. In that case, return 'None' instead of actual spatial bounds. Harmony service lib wrapper works with None result already.

### Overview of verification done

- Added a new unit test on the S6 granule (contains groups). This test uses a bbox that contains no data and results in an empty subset. This now results in a successful subset.
- Updated the existing harmony unit test to use the S6 granule (mentioned above) with an empty result instead of mocking a `None` result from `subset.subset`.
- Manually tested (l2ss-py CLI) on the following data, all granules worked without errors.

| Collection                                          | Granule                                                                  |
| --------------------------------------------------- | ------------------------------------------------------------------------ |
| SWOT_SIMULATED_L2_KARIN_SSH_ECCO_LLC4320_CALVAL_V1  | SWOT_L2_LR_SSH_Expert_368_012_20121111T235910_20121112T005015_DG10_01.nc |
| SWOT_SIMULATED_L2_KARIN_SSH_ECCO_LLC4320_SCIENCE_V1 | SWOT_L2_LR_SSH_Expert_018_290_20121112T003212_20121112T012339_DG10_01.nc |
| SWOT_SIMULATED_L2_KARIN_SSH_GLORYS_CALVAL_V1        | SWOT_L2_LR_SSH_Expert_632_018_20151230T234907_20151231T004012_DG10_01.nc |
| SWOT_SIMULATED_L2_NADIR_SSH_ECCO_LLC4320_CALVAL_V1  | SWOT_GPR_2PTP368_012_20121111_235911_20121112_005015.nc                  |
| SWOT_SIMULATED_L2_NADIR_SSH_ECCO_LLC4320_SCIENCE_V1 | SWOT_GPR_2PTP018_290_20121112_003211_20121112_012337.nc                  |
| SWOT_SIMULATED_L2_NADIR_SSH_GLORYS_CALVAL_V1        | SWOT_GPR_2PTP001_003_20140412_134212_20140412_143317.nc                  |
| SWOT_SIMULATED_L2_NADIR_SSH_GLORYS_SCIENCE_V1       | SWOT_GPR_2PTP031_044_20151230_232032_20151231_001158.nc                  |


### Overview of integration done

N/A. Due to the fact that the above SWOT collections are not in UAT, this is difficult to test with a local harmony deployment.

## PR checklist:

* [X] Linted
* [X] Updated unit tests
* [X] Updated changelog
* [ ] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_