### PR TITLE
Utilize Launchpad for UMM-S update

### DIFF
--- a/.github/workflows/build-pipeline.yml
+++ b/.github/workflows/build-pipeline.yml
@@ -127,7 +127,7 @@ jobs:
           tag: ${{ env.software_version }}
           message: "Version ${{ env.software_version }}"
       - name: Publish UMM-S with new version
-        uses: podaac/cmr-umm-updater@0.1.1
+        uses: podaac/cmr-umm-updater@0.2.0
         if: |
           github.ref == 'refs/heads/main'    ||
           startsWith(github.ref, 'refs/heads/release')
@@ -137,8 +137,9 @@ jobs:
           env: ${{ env.venue }}
           version: ${{ env.software_version }}
         env:
-          cmr_user: ${{secrets.CMR_USER}}
-          cmr_pass: ${{secrets.CMR_PASS}}
+          LAUNCHPAD_TOKEN_SIT: ${{secrets.LAUNCHPAD_TOKEN_SIT}}
+          LAUNCHPAD_TOKEN_UAT: ${{secrets.LAUNCHPAD_TOKEN_UAT}}
+          LAUNCHPAD_TOKEN_OPS: ${{secrets.LAUNCHPAD_TOKEN_OPS}}
       - name: Build Docs
         run: |
           poetry run sphinx-build -b html ./docs docs/_build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [issues/50](https://github.com/podaac/l2ss-py/issues/50): Spatial bounds are computed correctly for grouped empty subset operations
 ### Changed 
+- Upgraded `cmr-umm-updater` to 0.2.0
 ### Deprecated 
 ### Removed
 ### Fixed


### PR DESCRIPTION
Github Issue: N/A

### Description

Upgrade `cmr-umm-updater` to version that supports Launchpad authentication.

### Overview of work done

- Upgraded `cmr-umm-updater` to 0.2.0, which supports Launchpad authentication.
- Added `secrets.LAUNCHPAD_TOKEN_SIT`/`UAT`/`OPS` which is used by 0.2.0 of `cmr-umm-updater`


### Overview of verification done


### Overview of integration done



## PR checklist:

* [ ] Linted
* [ ] Updated unit tests
* [X] Updated changelog
* [ ] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_