### PR TITLE
feature/issue-54: Bugfix - skip encoding when xr dataset is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 - [issues/48](https://github.com/podaac/l2ss-py/issues/48): get_epoch_time_var was not able to pick up the 'time' variable for the TROPOMI CH4 collection. Extra elif statement was added to get the full time variable returned.
+- [issues/54](https://github.com/podaac/l2ss-py/issues/54): Skip encoding when xr dataset is empty
 ### Security
 
 ## [1.3.0]

--- a/podaac/subsetter/subset.py
+++ b/podaac/subsetter/subset.py
@@ -1119,7 +1119,8 @@ def subset(file_to_subset, bbox, output_file, variables=None,  # pylint: disable
                 encoding = {}
                 compression = dict(zlib=True, complevel=5, _FillValue=None)
 
-                if (min_time or max_time) and any(dataset.dims.values()):
+                if (min_time or max_time) and not all(
+                        dim_size == 1 for dim_size in dataset.dims.values()):
                     encoding = {
                         var_name: {
                             'units': nc_dataset.variables[var_name].__dict__['units'],

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -1643,3 +1643,34 @@ class TestSubsetter(unittest.TestCase):
         )
 
         assert spatial_bounds is None
+
+    def test_empty_temporal_subset(self):
+        """
+        Test the edge case where a subsetted empty granule
+        (due to bbox) is temporally subset, which causes the encoding
+        step to fail due to size '1' data for each dimension.
+        """
+        #  37.707:38.484
+        bbox = np.array(((37.707, 38.484), (-13.265, -12.812)))
+        file = '20190927000500-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc'
+        output_file = "{}_{}".format(self._testMethodName, file)
+        min_time = '2019-09-01'
+        max_time = '2019-09-30'
+
+        subset.subset(
+            file_to_subset=join(self.test_data_dir, file),
+            bbox=bbox,
+            output_file=join(self.subset_output_dir, output_file),
+            min_time=min_time,
+            max_time=max_time
+        )
+
+        # Check that all times are within the given bounds. Open
+        # dataset using 'decode_times=True' for auto-conversions to
+        # datetime
+        ds = xr.open_dataset(
+            join(self.subset_output_dir, output_file),
+            decode_coords=False
+        )
+
+        assert all(dim_size == 1 for dim_size in ds.dims.values())


### PR DESCRIPTION
Github Issue: #54

### Description

Error occurring for the following edge case: temporal subset + empty spatial subset

### Overview of work done

[This encoding block](https://github.com/podaac/l2ss-py/blob/708bbcbe280e36c25341f8f0eb6c5640c6795b3b/podaac/subsetter/subset.py#L1122-L1131) fails when the dataset is empty. The dataset can be empty when the input bbox contains no data (this happens frequently in Harmony). This used to be handled correctly, but was broken by [PR 40](https://github.com/podaac/l2ss-py/pull/40) "Empty datasets retain dimensions of the original". That PR changed the resulting empty dataset so each dimension is retained but with size 1. The check for an empty dataset no longer works so would go into the encoding block, which does not work with empty datasets. 

### Overview of verification done

Added a unit test using existing MODIS_A granule, with spatial bounds that contained no data + temporal bounds. This recreated the issue before the fix was in place.

I also ran the l2ss-py CLI on the following granules using the exact params @jjmcnelis  provided in #54:

- 20190130221500-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc
- 20190130230500-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc
- 20190130234001-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc
- 20190130235000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc
- 20190131000000-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc

All subsetted successfully.

### Overview of integration done

N/A

## PR checklist:

* [X] Linted
* [X] Updated unit tests
* [X] Updated changelog
* [ ] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_