### PR TITLE
issue-78: Harmony adapter passes coordinate variables to l2ss-py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added Shapefile option to UMM-S entry
 - Added optional coordinate variable params
+- [issues/78](https://github.com/podaac/l2ss-py/issues/72): Pass coordinate variables from service to l2ss-py
 ### Changed 
 - Updated dependency versions
 ### Deprecated 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 - [issues/72](https://github.com/podaac/l2ss-py/issues/72). Fix SMAP_RSS_L2_SSS_V4 subsetting, changed calculate chunk function.
-- [issues/9](https://github.com/podaacpodaac/subsetter/subset_harmony.py:171:19:/l2ss-py/issues/9). Determinate coordinate variables using cf_xarray.
+- [issues/9](https://github.com/podaac/l2ss-py/issues/9). Determinate coordinate variables using cf_xarray.
 ### Security
 - Changed CLI step in build action to use snyk monitor so that report is uploaded to SNYK podaac org
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 - [issues/72](https://github.com/podaac/l2ss-py/issues/72). Fix SMAP_RSS_L2_SSS_V4 subsetting, changed calculate chunk function.
-- [issues/9](https://github.com/podaac/l2ss-py/issues/9). Determinate coordinate variables using cf_xarray.
+- [issues/9](https://github.com/podaacpodaac/subsetter/subset_harmony.py:171:19:/l2ss-py/issues/9). Determinate coordinate variables using cf_xarray.
 ### Security
 - Changed CLI step in build action to use snyk monitor so that report is uploaded to SNYK podaac org
 

--- a/podaac/subsetter/subset_harmony.py
+++ b/podaac/subsetter/subset_harmony.py
@@ -165,11 +165,7 @@ class L2SubsetterService(BaseHarmonyAdapter):
             subset_params['origin_source'] = asset.href
 
             self.logger.info('Calling l2ss-py subset with params %s', subset_params)
-
-            try:
-                result_bbox = subset.subset(**subset_params)
-            except Exception as e:
-                self.logger.error(f'Error while running l2ss-py {e}')
+            result_bbox = subset.subset(**subset_params)
 
             # Stage the output file with a conventional filename
             mime = 'application/x-netcdf4'

--- a/podaac/subsetter/subset_harmony.py
+++ b/podaac/subsetter/subset_harmony.py
@@ -117,18 +117,20 @@ class L2SubsetterService(BaseHarmonyAdapter):
                                       access_token=self.message.accessToken,
                                       cfg=self.config)
 
-            origin_source = asset.href
             message = self.message
+
+            # Dictionary of keywords params that will be passed into
+            # the l2ss-py subset function
+            subset_params = {}
 
             # Transform params to PO.DAAC subsetter arguments and invoke the subsetter
             harmony_bbox = [-180, -90, 180, 90]
-            shapefile_path = None
 
             if message.subset and message.subset.bbox:
                 harmony_bbox = message.subset.bbox
 
             if message.subset and message.subset.shape:
-                shapefile_path = download(
+                subset_params['shapefile_path'] = download(
                     message.subset.shape.href,
                     temp_dir,
                     logger=self.logger,
@@ -136,39 +138,48 @@ class L2SubsetterService(BaseHarmonyAdapter):
                     cfg=self.config
                 )
 
-            min_time = None
-            max_time = None
             if message.temporal:
-                min_time = message.temporal.start
-                max_time = message.temporal.end
+                subset_params['min_time'] = message.temporal.start
+                subset_params['max_time'] = message.temporal.end
 
-            bbox = harmony_to_podaac_bbox(harmony_bbox)
+            subset_params['bbox'] = harmony_to_podaac_bbox(harmony_bbox)
 
-            variables = None
             if source.variables:
-                variables = [variable.name for variable in source.process('variables')]
+                subset_params['variables'] = [variable.name for variable in source.process('variables')]
 
-            output_filename = f'{output_dir}/{os.path.basename(input_filename)}'
-            result_bbox = subset.subset(
-                input_filename,
-                bbox,
-                output_filename,
-                variables=variables,
-                min_time=min_time,
-                max_time=max_time,
-                origin_source=origin_source,
-                shapefile=shapefile_path
-            )
+            if source.coordinateVariables:
+                coordinate_variables = list(
+                    filter(lambda var: var.type and var.subtype, source.coordinateVariables)
+                )
+                filter_by_subtype = lambda vars, subtype: list(
+                    map(lambda var: var.name, filter(
+                            lambda var: var.subtype == subtype, vars
+                    ))
+                )
+                subset_params['lat_var_names'] = filter_by_subtype(coordinate_variables, 'LATITUDE')
+                subset_params['lon_var_names'] = filter_by_subtype(coordinate_variables, 'LONGITUDE')
+                subset_params['time_var_names'] = filter_by_subtype(coordinate_variables, 'TIME')
+
+            subset_params['output_file'] = f'{output_dir}/{os.path.basename(input_filename)}'
+            subset_params['file_to_subset'] = input_filename
+            subset_params['origin_source'] = asset.href
+
+            self.logger.info('Calling l2ss-py subset with params %s', subset_params)
+
+            try:
+                result_bbox = subset.subset(**subset_params)
+            except Exception as e:
+                self.logger.error(f'Error while running l2ss-py {e}')
 
             # Stage the output file with a conventional filename
             mime = 'application/x-netcdf4'
             operations = dict(
-                variable_subset=variables,
+                variable_subset=subset_params.get('variables'),
                 is_subsetted=bool(result_bbox is not None)
             )
             staged_filename = generate_output_filename(asset.href, '.nc4', **operations)
 
-            url = stage(output_filename,
+            url = stage(subset_params['output_file'],
                         staged_filename,
                         mime,
                         location=message.stagingLocation,

--- a/poetry.lock
+++ b/poetry.lock
@@ -526,7 +526,7 @@ numpy = ">=1.14.5"
 
 [[package]]
 name = "harmony-service-lib"
-version = "1.0.14"
+version = "1.0.15"
 description = "A library for Python-based Harmony services to parse incoming messages, fetch data, stage data, and call back to Harmony"
 category = "main"
 optional = true
@@ -1639,7 +1639,7 @@ harmony = ["harmony-service-lib", "pystac"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4.0"
-content-hash = "bb9ef7e4160f540c6089f707a2d3e32d468203583b2377ca846b936e566b88e1"
+content-hash = "18885852c75513236ab63b5889bf64cfd2741816eadbc53c1e43e9f89f17dd8e"
 
 [metadata.files]
 alabaster = [
@@ -1810,7 +1810,6 @@ cloudpickle = [
 ]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
-    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 coverage = [
     {file = "coverage-6.3.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9b27d894748475fa858f9597c0ee1d4829f44683f3813633aaf94b19cb5453cf"},
@@ -1952,8 +1951,8 @@ h5py = [
     {file = "h5py-3.6.0.tar.gz", hash = "sha256:8752d2814a92aba4e2b2a5922d2782d0029102d99caaf3c201a566bc0b40db29"},
 ]
 harmony-service-lib = [
-    {file = "harmony-service-lib-1.0.14.tar.gz", hash = "sha256:1b1e0fc77977403ddba866a29906269a87b640f782bd64362baede2163131a5e"},
-    {file = "harmony_service_lib-1.0.14-py3-none-any.whl", hash = "sha256:53b9d5b0ef9e1dec1d9dd898840e609271208322547447c31af240e2849bd485"},
+    {file = "harmony-service-lib-1.0.15.tar.gz", hash = "sha256:da8a6589ddf50f8e3408e048c62d21849d0884363a8bd4ca592f8bfe17314bf4"},
+    {file = "harmony_service_lib-1.0.15-py3-none-any.whl", hash = "sha256:2ea5b0b63679f2f24ccf9466216ef898ad51d9733d3e205764ffa2373877516d"},
 ]
 heapdict = [
     {file = "HeapDict-1.0.1-py3-none-any.whl", hash = "sha256:6065f90933ab1bb7e50db403b90cab653c853690c5992e69294c2de2b253fc92"},
@@ -2266,18 +2265,21 @@ pbr = [
 pillow = [
     {file = "Pillow-9.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:af79d3fde1fc2e33561166d62e3b63f0cc3e47b5a3a2e5fea40d4917754734ea"},
     {file = "Pillow-9.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:55dd1cf09a1fd7c7b78425967aacae9b0d70125f7d3ab973fadc7b5abc3de652"},
+    {file = "Pillow-9.1.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:66822d01e82506a19407d1afc104c3fcea3b81d5eb11485e593ad6b8492f995a"},
     {file = "Pillow-9.1.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a5eaf3b42df2bcda61c53a742ee2c6e63f777d0e085bbc6b2ab7ed57deb13db7"},
     {file = "Pillow-9.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:01ce45deec9df310cbbee11104bae1a2a43308dd9c317f99235b6d3080ddd66e"},
     {file = "Pillow-9.1.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:aea7ce61328e15943d7b9eaca87e81f7c62ff90f669116f857262e9da4057ba3"},
     {file = "Pillow-9.1.0-cp310-cp310-win32.whl", hash = "sha256:7a053bd4d65a3294b153bdd7724dce864a1d548416a5ef61f6d03bf149205160"},
     {file = "Pillow-9.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:97bda660702a856c2c9e12ec26fc6d187631ddfd896ff685814ab21ef0597033"},
     {file = "Pillow-9.1.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:21dee8466b42912335151d24c1665fcf44dc2ee47e021d233a40c3ca5adae59c"},
+    {file = "Pillow-9.1.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b6d4050b208c8ff886fd3db6690bf04f9a48749d78b41b7a5bf24c236ab0165"},
     {file = "Pillow-9.1.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5cfca31ab4c13552a0f354c87fbd7f162a4fafd25e6b521bba93a57fe6a3700a"},
     {file = "Pillow-9.1.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ed742214068efa95e9844c2d9129e209ed63f61baa4d54dbf4cf8b5e2d30ccf2"},
     {file = "Pillow-9.1.0-cp37-cp37m-win32.whl", hash = "sha256:c9efef876c21788366ea1f50ecb39d5d6f65febe25ad1d4c0b8dff98843ac244"},
     {file = "Pillow-9.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:de344bcf6e2463bb25179d74d6e7989e375f906bcec8cb86edb8b12acbc7dfef"},
     {file = "Pillow-9.1.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:17869489de2fce6c36690a0c721bd3db176194af5f39249c1ac56d0bb0fcc512"},
     {file = "Pillow-9.1.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:25023a6209a4d7c42154073144608c9a71d3512b648a2f5d4465182cb93d3477"},
+    {file = "Pillow-9.1.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8782189c796eff29dbb37dd87afa4ad4d40fc90b2742704f94812851b725964b"},
     {file = "Pillow-9.1.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:463acf531f5d0925ca55904fa668bb3461c3ef6bc779e1d6d8a488092bdee378"},
     {file = "Pillow-9.1.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f42364485bfdab19c1373b5cd62f7c5ab7cc052e19644862ec8f15bb8af289e"},
     {file = "Pillow-9.1.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:3fddcdb619ba04491e8f771636583a7cc5a5051cd193ff1aa1ee8616d2a692c5"},
@@ -2285,6 +2287,7 @@ pillow = [
     {file = "Pillow-9.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:c24f718f9dd73bb2b31a6201e6db5ea4a61fdd1d1c200f43ee585fc6dcd21b34"},
     {file = "Pillow-9.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:fb89397013cf302f282f0fc998bb7abf11d49dcff72c8ecb320f76ea6e2c5717"},
     {file = "Pillow-9.1.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c870193cce4b76713a2b29be5d8327c8ccbe0d4a49bc22968aa1e680930f5581"},
+    {file = "Pillow-9.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69e5ddc609230d4408277af135c5b5c8fe7a54b2bdb8ad7c5100b86b3aab04c6"},
     {file = "Pillow-9.1.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:35be4a9f65441d9982240e6966c1eaa1c654c4e5e931eaf580130409e31804d4"},
     {file = "Pillow-9.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:82283af99c1c3a5ba1da44c67296d5aad19f11c535b551a5ae55328a317ce331"},
     {file = "Pillow-9.1.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a325ac71914c5c043fa50441b36606e64a10cd262de12f7a179620f579752ff8"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ netCDF4 = "^1.5"
 xarray = {version = "^.18", extras = ["parallel"]}
 geopandas ="0.6.1"
 Shapely = "^1.7.1"
-harmony-service-lib = { version = "^1", optional = true }
+harmony-service-lib = { version = "^1.0.15", optional = true }
 pystac = { version = "^0.5.3", optional = true }
 julian = "^0.14"
 importlib-metadata = "^4.8.1"

--- a/tests/test_subset_harmony.py
+++ b/tests/test_subset_harmony.py
@@ -35,9 +35,8 @@ from harmony.util import config
 def temp_dir():
     test_data_dir = os.path.dirname(os.path.realpath(__file__))
     temp_dir = tempfile.mkdtemp(dir=test_data_dir)
-    print(f'{temp_dir=}')
     yield temp_dir
-    # shutil.rmtree(temp_dir)
+    shutil.rmtree(temp_dir)
 
 
 def spy_on(method):


### PR DESCRIPTION
Github Issue: #78 

### Description

Harmony adapter passes coordinate variables to l2ss-py

### Overview of work done

- Upgraded `harmony-service-lib` to 1.0.15
- Updated harmony adapter code to pass coordinate variables to l2ss-py, if provided
- Cleaned up code so all l2ss-py params are in dictionary

### Overview of verification done

- Added unit test with coordinate variables passed in

### Overview of integration done

- Tested with local Harmony deployment. `C1234724470-POCLOUD` is UAT collection with coord variable metadata in place. This seemed to work as expected.

```
http://localhost:3000/C1234724470-POCLOUD/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?subset=lat(0%3A90)&maxResults=2
```

You can see in the log message that I added that the lat/lon/time vars are passed in:

```
2022-05-23T19:01:10.346Z [debug]: INFO:root:Calling l2ss-py subset with params {'bbox': array([[-180,  180],
       [   0,   90]]), 'lat_var_names': ['lat'], 'lon_var_names': ['lon'], 'time_var_names': ['time'], 'output_file': '/home/dockeruser/data/81066b2831bab8ab47621d552e97e029673fe6d1cfb59ff2d5fa2ca926c1ec6b.nc', 'file_to_subset': '/tmp/tmp7pq3445o/81066b2831bab8ab47621d552e97e029673fe6d1cfb59ff2d5fa2ca926c1ec6b.nc', 'origin_source': 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20020704000506-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc'}
{"message": "Calling l2ss-py subset with params {'bbox': array([[-180,  180],\n       [   0,   90]]), 'lat_var_names': ['lat'], 'lon_var_names': ['lon'], 'time_var_names': ['time'], 'output_file': '/home/dockeruser/data/81066b2831bab8ab47621d552e97e029673fe6d1cfb59ff2d5fa2ca926c1ec6b.nc', 'file_to_subset': '/tmp/tmp7pq3445o/81066b2831bab8ab47621d552e97e029673fe6d1cfb59ff2d5fa2ca926c1ec6b.nc', 'origin_source': 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20020704000506-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc'}", "user": "skperez", "requestId": "d2e4f851-22c7-4e9d-b579-dd107e216748", "timestamp": "2022-05-23T19:01:10.344380Z", "level": "INFO", "application": "/home/dockeruser/.local/bin/l2ss_harmony"}
```

## PR checklist:

* [X] Linted
* [X] Updated unit tests
* [X] Updated changelog
* [X] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_