### PR TITLE
feature/issue-88: Fix push tag github actions step

### DIFF
--- a/.github/workflows/build-pipeline.yml
+++ b/.github/workflows/build-pipeline.yml
@@ -118,14 +118,15 @@ jobs:
           git commit -am "/version ${{ env.software_version }}"
           git push
       - name: Push Tag
-        uses: actions-ecosystem/action-push-tag@v1
         if: |
           github.ref == 'refs/heads/develop' ||
           github.ref == 'refs/heads/main'    ||
           startsWith(github.ref, 'refs/heads/release')
-        with:
-          tag: ${{ env.software_version }}
-          message: "Version ${{ env.software_version }}"
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git tag -a "${{ env.software_version }}" -m "Version ${{ env.software_version }}"
+          git push origin "${{ env.software_version }}"
       - name: Publish UMM-S with new version
         uses: podaac/cmr-umm-updater@0.2.1
         if: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [issues/78](https://github.com/podaac/l2ss-py/issues/72): Pass coordinate variables from service to l2ss-py
 ### Changed 
 - Updated dependency versions
+- [issues/88](https://github.com/podaac/l2ss-py/issues/88): Build pipeline manually pushes tag rather than use action-push-tag
 ### Deprecated 
 ### Removed
 ### Fixed

--- a/podaac/subsetter/subset_harmony.py
+++ b/podaac/subsetter/subset_harmony.py
@@ -151,9 +151,9 @@ class L2SubsetterService(BaseHarmonyAdapter):
                 coordinate_variables = list(
                     filter(lambda var: var.type and var.subtype, source.coordinateVariables)
                 )
-                def filter_by_subtype(vars, subtype):
+                def filter_by_subtype(variables, subtype):
                     return list(map(lambda var: var.name, filter(
-                                lambda var: var.subtype == subtype, vars
+                                lambda var: var.subtype == subtype, variables
                     )))
                 subset_params['lat_var_names'] = filter_by_subtype(coordinate_variables, 'LATITUDE')
                 subset_params['lon_var_names'] = filter_by_subtype(coordinate_variables, 'LONGITUDE')

--- a/podaac/subsetter/subset_harmony.py
+++ b/podaac/subsetter/subset_harmony.py
@@ -151,11 +151,10 @@ class L2SubsetterService(BaseHarmonyAdapter):
                 coordinate_variables = list(
                     filter(lambda var: var.type and var.subtype, source.coordinateVariables)
                 )
-                filter_by_subtype = lambda vars, subtype: list(
-                    map(lambda var: var.name, filter(
-                            lambda var: var.subtype == subtype, vars
-                    ))
-                )
+                def filter_by_subtype(vars, subtype):
+                    return list(map(lambda var: var.name, filter(
+                                lambda var: var.subtype == subtype, vars
+                    )))
                 subset_params['lat_var_names'] = filter_by_subtype(coordinate_variables, 'LATITUDE')
                 subset_params['lon_var_names'] = filter_by_subtype(coordinate_variables, 'LONGITUDE')
                 subset_params['time_var_names'] = filter_by_subtype(coordinate_variables, 'TIME')

--- a/podaac/subsetter/subset_harmony.py
+++ b/podaac/subsetter/subset_harmony.py
@@ -151,9 +151,10 @@ class L2SubsetterService(BaseHarmonyAdapter):
                 coordinate_variables = list(
                     filter(lambda var: var.type and var.subtype, source.coordinateVariables)
                 )
+
                 def filter_by_subtype(variables, subtype):
                     return list(map(lambda var: var.name, filter(
-                                lambda var: var.subtype == subtype, variables
+                        lambda var: var.subtype == subtype, variables
                     )))
                 subset_params['lat_var_names'] = filter_by_subtype(coordinate_variables, 'LATITUDE')
                 subset_params['lon_var_names'] = filter_by_subtype(coordinate_variables, 'LONGITUDE')


### PR DESCRIPTION
Github Issue: #88 

### Description

The github action "action-push-tag" is not currently working, see thread: https://github.com/actions-ecosystem/action-push-tag/issues/10

As a workaround we will manually tag rather than relying on this github action. If they eventually fix this we should move back to using it.

### Overview of work done

- Updated github action `Push Tag` step to push tag manually
- Fixed linting error introduced by https://github.com/podaac/l2ss-py/pull/90. I have no idea why this linting error was not caught by that build pipeline.


### Overview of verification done

None. We'll have to test this once we merge to develop, as the `Push Tag` step is not executed until then.

### Overview of integration done

N/A

## PR checklist:

* [X] Linted
* [ ] Updated unit tests
* [X] Updated changelog
* [ ] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_