### PR TITLE
Feature/issue 95: Fix OMI nonvariable subsetting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated 
 ### Removed
 ### Fixed
-- Fix non variable subsets for OMI since variables are not in the same group as the lat lon variables 
-- [issue/95](https://github.com/podaac/l2ss-py/issues/95): OMI non-variable subsetting
+- [issue/95](https://github.com/podaac/l2ss-py/issues/95): Fix non variable subsets for OMI since variables are not in the same group as the lat lon variables 
 ### Security
 
 ## [1.5.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated 
 ### Removed
 ### Fixed
+- Fix non variable subsets for OMI since variables are not in the same group as the lat lon variables 
+- [issue/95](https://github.com/podaac/l2ss-py/issues/95): OMI non-variable subsetting
 ### Security
 
 ## [1.5.0]

--- a/podaac/subsetter/subset.py
+++ b/podaac/subsetter/subset.py
@@ -768,7 +768,6 @@ def subset_with_bbox(dataset, lat_var_names, lon_var_names, time_var_names, vari
                     var for var in dataset.data_vars.keys()
                     if var in variables and var not in group_vars and not var.startswith(tuple(lat_var_prefix))
                 ])
-                
             else:
                 group_vars.extend([
                     var for var in dataset.data_vars.keys()
@@ -1221,12 +1220,10 @@ def subset(file_to_subset, bbox, output_file, variables=None,
             ]
 
             dataset = dataset.drop_vars(vars_to_drop)
-            
         if shapefile:
             datasets = [
                 subset_with_shapefile(dataset, lat_var_names[0], lon_var_names[0], shapefile, cut, chunks)
             ]
-        
         elif bbox is not None:
             datasets = subset_with_bbox(
                 dataset=dataset,

--- a/podaac/subsetter/subset.py
+++ b/podaac/subsetter/subset.py
@@ -768,6 +768,12 @@ def subset_with_bbox(dataset, lat_var_names, lon_var_names, time_var_names, vari
                     var for var in dataset.data_vars.keys()
                     if var in variables and var not in group_vars and not var.startswith(tuple(lat_var_prefix))
                 ])
+                
+            else:
+                group_vars.extend([
+                    var for var in dataset.data_vars.keys()
+                    if var not in group_vars and not var.startswith(tuple(lat_var_prefix))
+                    ])
 
         else:
             group_vars = list(dataset.keys())
@@ -1213,12 +1219,14 @@ def subset(file_to_subset, bbox, output_file, variables=None,
                 and var_name not in lon_var_names
                 and var_name not in time_var_names
             ]
-            dataset = dataset.drop_vars(vars_to_drop)
 
+            dataset = dataset.drop_vars(vars_to_drop)
+            
         if shapefile:
             datasets = [
                 subset_with_shapefile(dataset, lat_var_names[0], lon_var_names[0], shapefile, cut, chunks)
             ]
+        
         elif bbox is not None:
             datasets = subset_with_bbox(
                 dataset=dataset,
@@ -1231,6 +1239,7 @@ def subset(file_to_subset, bbox, output_file, variables=None,
                 min_time=min_time,
                 max_time=max_time
             )
+
         else:
             raise ValueError('Either bbox or shapefile must be provided')
 

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -1285,6 +1285,34 @@ class TestSubsetter(unittest.TestCase):
         for var_name, variable in in_nc.variables.items():
             assert in_nc[var_name].shape == out_nc[var_name].shape
 
+    def test_omi_novars_subset(self):
+        """
+        Check that the OMI variables are conserved when no variable are specified
+        the data field and lat/lon are in different groups
+        """
+        omi_dir = join(self.test_data_dir, 'OMSO2')
+        omi_file = 'OMI-Aura_L2-OMSO2_2020m0116t1207-o82471_v003-2020m0223t142939.he5'
+
+        bbox = np.array(((-180, 90), (-90, 90)))
+        output_file = "{}_{}".format(self._testMethodName, omi_file)
+        shutil.copyfile(
+            os.path.join(omi_dir, omi_file),
+            os.path.join(self.subset_output_dir, omi_file)
+        )
+        box_test = subset.subset(
+            file_to_subset=join(self.subset_output_dir, omi_file),
+            bbox=bbox,
+            output_file=join(self.subset_output_dir, output_file),
+        )
+        # check if the box_test is
+
+        in_nc = nc.Dataset(join(omi_dir, omi_file))
+        out_nc = nc.Dataset(join(self.subset_output_dir, output_file))
+
+        for var_name, variable in in_nc.variables.items():
+            assert in_nc[var_name].shape == out_nc[var_name].shape
+
+
     def test_root_group(self):
         """test that the GROUP_DELIM string, '__', is added to variables in the root group"""
 


### PR DESCRIPTION
Github Issue: #95 

### Description

OMI non variable subsets don't include variables in the Data fields group. Adding logic if no variables are given.

### Overview of work done

If variables do not exist, and the other variables to the group_vars list to be included in the dataset.

### Overview of verification done

Do a non variables subset and make sure the variables in the original granule are conserved.

### Overview of integration done

_Explain how this change was integration tested. Provide screenshots or logs if appropriate. An example of this would be a local Harmony deployment._

## PR checklist:

* [ x] Linted
* [ x] Updated unit tests
* [x ] Updated changelog
* [ ] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_