### PR TITLE
feature/issue-98 Add logic to handle time decoding for he5 tai93 files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Added logic to handle time decoding for he5 tai93 files. Xarray was not decoding the time
-  thus timestamp comparisons were failing
-- [issue/98](https://github.com/podaac/l2ss-py/issues/98): Add OMI Temporal Subsetting
+- [issue/98](https://github.com/podaac/l2ss-py/issues/98): Added logic to handle time decoding for he5 tai93 files. Changed the min and max
+inputs to tai93 format and compared to the timeformat in the file
 ### Changed 
 ### Deprecated 
 ### Removed
-### Fixed
-- Fix non variable subsets for OMI since variables are not in the same group as the lat lon variables 
+### Fixed 
 - [issue/95](https://github.com/podaac/l2ss-py/issues/95): Fix non variable subsets for OMI since variables are not in the same group as the lat lon variables 
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added logic to handle time decoding for he5 tai93 files. Xarray was not decoding the time
   thus timestamp comparisons were failing
-- [issue/98](https://github.com/podaac/l2ss-py/issues/98): OMI Temporal Subsetting
+- [issue/98](https://github.com/podaac/l2ss-py/issues/98): 
 ### Changed 
 ### Deprecated 
 ### Removed
 ### Fixed
-<<<<<<< HEAD
 - Fix non variable subsets for OMI since variables are not in the same group as the lat lon variables 
-- [issue/95](https://github.com/podaac/l2ss-py/issues/95): OMI non-variable subsetting
-=======
 - [issue/95](https://github.com/podaac/l2ss-py/issues/95): Fix non variable subsets for OMI since variables are not in the same group as the lat lon variables 
->>>>>>> develop
+
 ### Security
 
 ## [1.5.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added logic to handle time decoding for he5 tai93 files. Xarray was not decoding the time
   thus timestamp comparisons were failing
-- [issue/98](https://github.com/podaac/l2ss-py/issues/98): 
+- [issue/98](https://github.com/podaac/l2ss-py/issues/98): Add OMI Temporal Subsetting
 ### Changed 
 ### Deprecated 
 ### Removed
@@ -17,7 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [issue/95](https://github.com/podaac/l2ss-py/issues/95): Fix non variable subsets for OMI since variables are not in the same group as the lat lon variables 
 
 ### Security
-
 ## [1.5.0]
 ### Added
 - Added Shapefile option to UMM-S entry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- [issue/98](https://github.com/podaac/l2ss-py/issues/98): Added logic to handle time decoding for he5 tai93 files. Changed the min and max
-inputs to tai93 format and compared to the timeformat in the file
+- [issue/98](https://github.com/podaac/l2ss-py/issues/98): Added logic to handle time decoding for he5 tai93 files. Changed the min and max inputs to tai93 format and compared to the time format in the file
 ### Changed 
 ### Deprecated 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated 
 ### Removed
 ### Fixed
+- Fix non variable subsets for OMI since variables are not in the same group as the lat lon variables 
+- [issue/95](https://github.com/podaac/l2ss-py/issues/95): OMI non-variable subsetting
 ### Security
 
 ## [1.5.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Added logic to handle time decoding for he5 tai93 files. Xarray was not decoding the time
+  thus timestamp comparisons were failing
+- [issue/98](https://github.com/podaac/l2ss-py/issues/98): OMI Temporal Subsetting
 ### Changed 
 ### Deprecated 
 ### Removed

--- a/podaac/subsetter/subset.py
+++ b/podaac/subsetter/subset.py
@@ -682,7 +682,6 @@ def build_temporal_cond(min_time, max_time, dataset, time_var_name):
 
     def build_cond(str_timestamp, compare):
         timestamp = translate_timestamp(str_timestamp)
-        
         if np.issubdtype(dataset[time_var_name].dtype, np.dtype(np.datetime64)):
             timestamp = pd.to_datetime(timestamp)
         if np.issubdtype(dataset[time_var_name].dtype, np.dtype(np.timedelta64)):
@@ -700,8 +699,8 @@ def build_temporal_cond(min_time, max_time, dataset, time_var_name):
                 timestamp = np.datetime64(timestamp) - epoch_datetime
 
         if np.issubdtype(dataset[time_var_name].dtype, np.dtype(float)):
-            dt = np.datetime64(dataset[time_var_name].attrs['Units'][-10:])
-            timestamp = (np.datetime64(timestamp) - dt).astype('timedelta64[s]').astype('float')
+            start_date = np.datetime64(dataset[time_var_name].attrs['Units'][-10:])
+            timestamp = (np.datetime64(timestamp) - start_date).astype('timedelta64[s]').astype('float')
 
         return compare(dataset[time_var_name], timestamp)
 
@@ -1190,9 +1189,8 @@ def subset(file_to_subset, bbox, output_file, variables=None,
         'mask_and_scale': False,
         'decode_times': False
     }
-    
     if min_time or max_time:
-        args['decode_times'] = True  
+        args['decode_times'] = True
 
     with xr.open_dataset(
             xr.backends.NetCDF4DataStore(nc_dataset),

--- a/podaac/subsetter/subset.py
+++ b/podaac/subsetter/subset.py
@@ -768,7 +768,6 @@ def subset_with_bbox(dataset, lat_var_names, lon_var_names, time_var_names, vari
                     var for var in dataset.data_vars.keys()
                     if var in variables and var not in group_vars and not var.startswith(tuple(lat_var_prefix))
                 ])
-                
             else:
                 group_vars.extend([
                     var for var in dataset.data_vars.keys()
@@ -1221,12 +1220,10 @@ def subset(file_to_subset, bbox, output_file, variables=None,
             ]
 
             dataset = dataset.drop_vars(vars_to_drop)
-            
         if shapefile:
             datasets = [
                 subset_with_shapefile(dataset, lat_var_names[0], lon_var_names[0], shapefile, cut, chunks)
             ]
-        
         elif bbox is not None:
             datasets = subset_with_bbox(
                 dataset=dataset,

--- a/podaac/subsetter/subset.py
+++ b/podaac/subsetter/subset.py
@@ -548,14 +548,14 @@ def get_time_epoch_var(dataset, time_var_name):
         The name of the epoch time variable
     """
     time_var = dataset[time_var_name]
-    print (list(dataset.variables.keys()))
+
     if 'comment' in time_var.attrs:
         epoch_var_name = time_var.attrs['comment'].split('plus')[0].strip()
     elif 'time' in dataset.variables.keys() and time_var_name != 'time':
         epoch_var_name = 'time'
-    elif any('time' in s.lower() for s in list(dataset.variables.keys())) and time_var_name != 'time':
+    elif any('time' in s for s in list(dataset.variables.keys())) and time_var_name != 'time':
         for i in list(dataset.variables.keys()):
-            group_list = i.lower().split(GROUP_DELIM)
+            group_list = i.split(GROUP_DELIM)
             if group_list[-1] == 'time':
                 epoch_var_name = i
                 break

--- a/podaac/subsetter/subset.py
+++ b/podaac/subsetter/subset.py
@@ -768,6 +768,12 @@ def subset_with_bbox(dataset, lat_var_names, lon_var_names, time_var_names, vari
                     var for var in dataset.data_vars.keys()
                     if var in variables and var not in group_vars and not var.startswith(tuple(lat_var_prefix))
                 ])
+                
+            else:
+                group_vars.extend([
+                    var for var in dataset.data_vars.keys()
+                    if var not in group_vars and not var.startswith(tuple(lat_var_prefix))
+                    ])
 
         else:
             group_vars = list(dataset.keys())
@@ -1213,12 +1219,14 @@ def subset(file_to_subset, bbox, output_file, variables=None,
                 and var_name not in lon_var_names
                 and var_name not in time_var_names
             ]
-            dataset = dataset.drop_vars(vars_to_drop)
 
+            dataset = dataset.drop_vars(vars_to_drop)
+            
         if shapefile:
             datasets = [
                 subset_with_shapefile(dataset, lat_var_names[0], lon_var_names[0], shapefile, cut, chunks)
             ]
+        
         elif bbox is not None:
             datasets = subset_with_bbox(
                 dataset=dataset,
@@ -1231,6 +1239,7 @@ def subset(file_to_subset, bbox, output_file, variables=None,
                 min_time=min_time,
                 max_time=max_time
             )
+
         else:
             raise ValueError('Either bbox or shapefile must be provided')
 

--- a/podaac/subsetter/subset.py
+++ b/podaac/subsetter/subset.py
@@ -548,14 +548,14 @@ def get_time_epoch_var(dataset, time_var_name):
         The name of the epoch time variable
     """
     time_var = dataset[time_var_name]
-
+    print (list(dataset.variables.keys()))
     if 'comment' in time_var.attrs:
         epoch_var_name = time_var.attrs['comment'].split('plus')[0].strip()
     elif 'time' in dataset.variables.keys() and time_var_name != 'time':
         epoch_var_name = 'time'
-    elif any('time' in s for s in list(dataset.variables.keys())) and time_var_name != 'time':
+    elif any('time' in s.lower() for s in list(dataset.variables.keys())) and time_var_name != 'time':
         for i in list(dataset.variables.keys()):
-            group_list = i.split(GROUP_DELIM)
+            group_list = i.lower().split(GROUP_DELIM)
             if group_list[-1] == 'time':
                 epoch_var_name = i
                 break
@@ -682,11 +682,10 @@ def build_temporal_cond(min_time, max_time, dataset, time_var_name):
 
     def build_cond(str_timestamp, compare):
         timestamp = translate_timestamp(str_timestamp)
-
+        
         if np.issubdtype(dataset[time_var_name].dtype, np.dtype(np.datetime64)):
             timestamp = pd.to_datetime(timestamp)
         if np.issubdtype(dataset[time_var_name].dtype, np.dtype(np.timedelta64)):
-
             if is_time_mjd(dataset, time_var_name):
                 # mjd when timedelta based on
                 mjd_datetime = datetime_from_mjd(dataset, time_var_name)
@@ -699,6 +698,10 @@ def build_temporal_cond(min_time, max_time, dataset, time_var_name):
                 epoch_time_var_name = get_time_epoch_var(dataset, time_var_name)
                 epoch_datetime = dataset[epoch_time_var_name].values[0]
                 timestamp = np.datetime64(timestamp) - epoch_datetime
+
+        if np.issubdtype(dataset[time_var_name].dtype, np.dtype(float)):
+            dt = np.datetime64(dataset[time_var_name].attrs['Units'][-10:])
+            timestamp = (np.datetime64(timestamp) - dt).astype('timedelta64[s]').astype('float')
 
         return compare(dataset[time_var_name], timestamp)
 
@@ -1187,15 +1190,14 @@ def subset(file_to_subset, bbox, output_file, variables=None,
         'mask_and_scale': False,
         'decode_times': False
     }
-
+    
     if min_time or max_time:
-        args['decode_times'] = True
+        args['decode_times'] = True  
 
     with xr.open_dataset(
             xr.backends.NetCDF4DataStore(nc_dataset),
             **args
     ) as dataset:
-
         lat_var_names, lon_var_names, time_var_names = get_coordinate_variable_names(
             dataset=dataset,
             lat_var_names=lat_var_names,

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -1285,6 +1285,34 @@ class TestSubsetter(unittest.TestCase):
         for var_name, variable in in_nc.variables.items():
             assert in_nc[var_name].shape == out_nc[var_name].shape
 
+    def test_omi_novars_subset(self):
+        """
+        Check that the OMI variables are conserved when no variable are specified
+        the data field and lat/lon are in different groups
+        """
+        omi_dir = join(self.test_data_dir, 'OMSO2')
+        omi_file = 'OMI-Aura_L2-OMSO2_2020m0116t1207-o82471_v003-2020m0223t142939.he5'
+
+        bbox = np.array(((-180, 90), (-90, 90)))
+        output_file = "{}_{}".format(self._testMethodName, omi_file)
+        shutil.copyfile(
+            os.path.join(omi_dir, omi_file),
+            os.path.join(self.subset_output_dir, omi_file)
+        )
+        box_test = subset.subset(
+            file_to_subset=join(self.subset_output_dir, omi_file),
+            bbox=bbox,
+            output_file=join(self.subset_output_dir, output_file),
+        )
+        # check if the box_test is
+
+        in_nc = nc.Dataset(join(omi_dir, omi_file))
+        out_nc = nc.Dataset(join(self.subset_output_dir, output_file))
+
+        for var_name, variable in in_nc.variables.items():
+            assert in_nc[var_name].shape == out_nc[var_name].shape
+
+
     def test_root_group(self):
         """test that the GROUP_DELIM string, '__', is added to variables in the root group"""
 

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -1646,6 +1646,62 @@ class TestSubsetter(unittest.TestCase):
         # subset should be present.
         assert set(np.append(['lat', 'lon', 'time'], variables)) == set(out_ds.data_vars.keys())
 
+    def test_temporal__he5file_subset(self):
+        """
+        Test that both a temporal subset can be executed for he5 files in the OMI
+        collections
+        """
+        
+        OMI_file_name = 'OMI-Aura_L2-OMSO2_2020m0116t1207-o82471_v003-2020m0223t142939.he5'
+        OMI_copy_file = 'OMI_copy_testing_2.he5'
+        shutil.copyfile(os.path.join(self.test_data_dir, 'OMSO2', OMI_file_name),
+                        os.path.join(self.subset_output_dir, OMI_copy_file))
+        min_time='2020-01-16T12:30:00Z'
+        max_time='2020-01-16T12:40:00Z'
+        bbox = np.array(((-180, 180), (-90, 90)))
+        nc_dataset, has_groups = subset.h5file_transform(os.path.join(self.subset_output_dir, OMI_copy_file))
+
+        args = {
+            'decode_coords': False,
+            'mask_and_scale': False,
+            'decode_times': False
+        }
+
+        if min_time or max_time:
+            args['decode_times'] = True  
+
+        with xr.open_dataset(
+                xr.backends.NetCDF4DataStore(nc_dataset),
+                **args
+        ) as dataset:
+            lat_var_names, lon_var_names, time_var_names = subset.get_coordinate_variable_names(
+                dataset=dataset,
+                lat_var_names=None,
+                lon_var_names=None,
+                time_var_names=None
+            )
+
+            datasets = subset.subset_with_bbox(
+                dataset=dataset,
+                lat_var_names=lat_var_names,
+                lon_var_names=lon_var_names,
+                time_var_names=time_var_names,
+                variables=None,
+                bbox=bbox,
+                cut=None,
+                min_time=min_time,
+                max_time=max_time
+            )
+            output_max = np.max(datasets[0][time_var_names[0]].values)
+            input_max = np.max(nc_dataset[time_var_names[0]])
+
+            output_min = np.min(datasets[0][time_var_names[0]].values)
+            input_min = np.min(nc_dataset[time_var_names[0]])
+
+            # test that the output granule was subsetted with time
+            assert input_max > output_max
+            assert input_min < output_min
+
     def test_temporal_subset_lines(self):
         bbox = np.array(((-180, 180), (-90, 90)))
         file = 'SWOT_L2_LR_SSH_Expert_368_012_20121111T235910_20121112T005015_DG10_01.nc'


### PR DESCRIPTION
Github Issue: #98 

### Description

Xarray was not decoding the OMI times for temporal subsetting

### Overview of work done

Add logic to get the TAI93 start date and then convert the timestamp to tai93 time

### Overview of verification done

Checked to see if min and max times were giving an expected temporal subset

### Overview of integration done

_Explain how this change was integration tested. Provide screenshots or logs if appropriate. An example of this would be a local Harmony deployment._

## PR checklist:

* [ x] Linted
* [ x] Updated unit tests
* [ x] Updated changelog
* [ ] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_