### PR TITLE
Feature/issue 85

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- [issue/85](https://github.com/podaac/l2ss-py/issues/85): Added initial poetry setup guidance to the README
+
 ## [2.1.0]
 ### Added
 ### Changed

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ Harmony service for subsetting L2 data. l2ss-py supports:
 
 If you would like to contribute to l2ss-py, refer to the [contribution document](CONTRIBUTING.md).
 
+## Initial setup, with poetry
+
+1. Follow the instructions for installing `poetry` [here](https://python-poetry.org/docs/).
+2. Install l2ss-py, with its dependencies, by running the following from the repository directory:
+
+```
+poetry install
+```
 
 ## How to test l2ss-py locally
 


### PR DESCRIPTION
Github Issue: #85 

### Description

This change adds a new, but very short, section to the README describing how to setup `poetry` and install l2ss-py dependencies.

### Overview of work done

Added the "Initial setup, with poetry" section and install command to `README.md`.

### Overview of verification done

Not applicable - only a README change.

### Overview of integration done

Not applicable - only a README change.

## PR checklist:

* [N/A] Linted
* [N/A] Updated unit tests
* [x] Updated changelog
* [N/A] Integration testing