### PR TITLE
Feature/issue 115

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- [issue/115](https://github.com/podaac/l2ss-py/issues/115): Added notes to README about installing "extra" harmony dependencies to avoid test suite fails. 
 - [issue/85](https://github.com/podaac/l2ss-py/issues/85): Added initial poetry setup guidance to the README
 
 ## [2.1.0]

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ If you would like to contribute to l2ss-py, refer to the [contribution document]
 poetry install
 ```
 
+***Note:*** l2ss-py can be installed as above and run without any dependency on `harmony`. 
+However, to additionally test the harmony adapter layer, 
+extra dependencies can be installed with `poetry install -E harmony`.
+
 ## How to test l2ss-py locally
 
 ### Unit tests
@@ -40,6 +44,11 @@ You can generate coverage reports as follows:
 ```
 poetry run pytest --junitxml=build/reports/pytest.xml --cov=podaac/ --cov-report=html -m "not aws and not integration" tests/
 ```
+
+***Note:*** The majority of the tests execute core functionality of l2ss-py without ever interacting with the harmony python modules. 
+The `test_subset_harmony` tests, however, are explicitly for testing the harmony adapter layer 
+and do require the harmony optional dependencies be installed, 
+as described above with the `-E harmony` argument.
 
 ### l2ss-py script
 


### PR DESCRIPTION
Github Issue: #115 

### Description

This change adds two notes to the README describing the `-E harmony` poetry installation option, which includes "extra" dependencies that are needed to successfully pass the `test_subset_harmony` tests in a local environment.

### Overview of work done

Added two paragraphs to README.md.

### Overview of verification done

Verified that no tests failed after installing via the `poetry install -E harmony` command, in a local Unix environment.

### Overview of integration done

Not applicable - only a README change.

## PR checklist:

* [N/A] Linted
* [N/A] Updated unit tests
* [x] Updated changelog
* [N/A] Integration testing
