### PR TITLE
feature/PODAAC-5065

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -63,7 +63,8 @@ confidence=
 disable=too-many-lines,
         too-many-arguments,
         too-many-locals,
-        no-member
+        no-member,
+        protected-access
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated 
 ### Removed
 ### Fixed
+- PODAAC-5065: integration with SMAP_RSS_L2_SSS_V5, fix way xarray open granules that have `seconds since 2000-1-1 0:0:0 0` as a time unit.
 ### Security
 
 ## [2.2.0]

--- a/podaac/subsetter/subset.py
+++ b/podaac/subsetter/subset.py
@@ -19,12 +19,12 @@ Functions related to subsetting a NetCDF file.
 """
 
 import datetime
-import dateutil
 import functools
 import json
 import operator
 import os
 from shutil import copy
+import dateutil
 
 import cf_xarray as cfxr
 import cftime
@@ -1229,13 +1229,16 @@ def subset(file_to_subset, bbox, output_file, variables=None,
         dateutil.parser.parse(time_test)
     except dateutil.parser._parser.ParserError:
         orig_decode_cf_datetime = xarray.coding.times.decode_cf_datetime
+
         def decode_cf_datetime(num_dates, units, calendar=None, use_cftime=None):
             if cftime is not None:
                 reference_time = cftime.num2date(0, units, calendar)
                 units = f"{units.split('since')[0]} since {reference_time}"
             return orig_decode_cf_datetime(num_dates, units, calendar, use_cftime)
         xarray.coding.times.decode_cf_datetime = decode_cf_datetime
-    except Exception as ex:
+    except IndexError:
+        pass
+    except AttributeError:
         pass
 
     if variables:


### PR DESCRIPTION
### Description

integrate SMAP_RSS_L2_SSS_V5

### Overview of work done

xarray had an error decoding time with units `seconds since 2000-1-1 0:0:0 0`, added in code to test if were able to parse the time unit if not modify the xarray.coding.times.decode_cf_datetime function to be able to modify the units to a parsable time unit. 

### Overview of verification done

tested l2ss harmony locally with SMAP_RSS_L2_SSS_V5 to make sure were able to subset. 

### Overview of integration done

_Explain how this change was integration tested. Provide screenshots or logs if appropriate. An example of this would be a local Harmony deployment._

## PR checklist:

* [x] Linted
* [ ] Updated unit tests
* [x] Updated changelog
* [x] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_