### PR TITLE
netcdf4 compression fix for s5p string subsetting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated 
 ### Removed
 ### Fixed
+- [issue/149](https://github.com/podaac/l2ss-py/issues/149): Fixed compression level for netCDF4 object variable creation into a string. Will need to address after netcdf4 rebuilds library.
+https://github.com/Unidata/netcdf4-python/issues/1236
 - [issue/143](https://github.com/podaac/l2ss-py/issues/143): Fixed bug when not specifying any variable subsetting for grouped datasets.
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated 
 ### Removed
 ### Fixed
-- [issue/149](https://github.com/podaac/l2ss-py/issues/149): Fixed compression level for netCDF4 object variable creation into a string. Will need to address after netcdf4 rebuilds library.
-https://github.com/Unidata/netcdf4-python/issues/1236
+- [issue/149](https://github.com/podaac/l2ss-py/issues/149): Fixed compression level for netCDF4 object variable creation into a string. Will need to address after netcdf4 rebuilds library. https://github.com/Unidata/netcdf4-python/issues/1236
 - [issue/143](https://github.com/podaac/l2ss-py/issues/143): Fixed bug when not specifying any variable subsetting for grouped datasets.
 ### Security
 

--- a/podaac/subsetter/group_handling.py
+++ b/podaac/subsetter/group_handling.py
@@ -175,8 +175,11 @@ def _rename_variables(dataset: xr.Dataset, base_dataset: nc.Dataset, start_date)
         var_attrs.pop('_FillValue', None)
         comp_args = {"zlib": True, "complevel": 1}
 
+        var_data = variable.data
         if variable.dtype == object:
-            var_group.createVariable(new_var_name, 'S1', var_dims, fill_value=fill_value, **comp_args)
+            comp_args = {"zlib": False, "complevel": 1}
+            var_group.createVariable(new_var_name, 'S4', var_dims, fill_value=fill_value, **comp_args)
+            var_data = np.array(variable.data)
         elif variable.dtype == 'timedelta64[ns]':
             var_group.createVariable(new_var_name, 'i4', var_dims, fill_value=fill_value, **comp_args)
         else:
@@ -187,7 +190,7 @@ def _rename_variables(dataset: xr.Dataset, base_dataset: nc.Dataset, start_date)
 
         # Copy data
         var_group.variables[new_var_name].set_auto_maskandscale(False)
-        var_group.variables[new_var_name][:] = variable.data
+        var_group.variables[new_var_name][:] = var_data
 
 
 def h5file_transform(finput: str) -> Tuple[nc.Dataset, bool]:

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -2040,6 +2040,29 @@ def test_var_subsetting_tropomi(data_dir, subset_output_dir, request):
 
     assert list(slash_dataset.groups['PRODUCT'].variables) == list(noslash_dataset.groups['PRODUCT'].variables)
 
+def test_tropomi_utc_time(data_dir, subset_output_dir, request):
+    """Verify that the time UTC values are conserved in S5P files"""
+    trop_dir = join(data_dir, 'tropomi')
+    trop_file = 'S5P_OFFL_L2__CH4____20190319T110835_20190319T125006_07407_01_010202_20190325T125810_subset.nc4'
+    variable = ['/PRODUCT/time_utc']
+    bbox = np.array(((-180, 180), (-90, 90)))
+    output_file = "{}_{}".format(request.node.name, trop_file)
+    shutil.copyfile(
+        os.path.join(trop_dir, trop_file),
+        os.path.join(subset_output_dir, trop_file)
+    )
+    subset.subset(
+        file_to_subset=join(subset_output_dir, trop_file),
+        bbox=bbox,
+        output_file=join(subset_output_dir, output_file),
+        variables=variable
+    )
+
+    in_nc_dataset = nc.Dataset(join(trop_dir, trop_file))
+    out_nc_dataset = nc.Dataset(join(subset_output_dir, output_file))
+
+    assert in_nc_dataset.groups['PRODUCT'].variables['time_utc'][:].squeeze()[0] ==\
+                    out_nc_dataset.groups['PRODUCT'].variables['time_utc'][:].squeeze()[0]
 
 def test_bad_time_unit(subset_output_dir):
     fill_val = -99999.0


### PR DESCRIPTION
Github Issue: #149 

### Description

Compression level changed for object type variables for netcdf4 4.9.0 workaround

### Overview of work done

_Summarize the work you did_

### Overview of verification done

_Summarize the testing and verification you've done. This includes unit tests or testing with specific data_

### Overview of integration done

_Explain how this change was integration tested. Provide screenshots or logs if appropriate. An example of this would be a local Harmony deployment._

## PR checklist:

* [ x] Linted
* [ x] Updated unit tests
* [x] Updated changelog
* [ ] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_