### PR TITLE
Feature/podaac 5538

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 - [issue/153](https://github.com/podaac/l2ss-py/issues/153): Remove the asc_node_tai93 variable when blank in the SNDR collections for xarray.decode_times to decode
+- PODAAC-5538: Reduce memory footprint of l2ss by loading each variable individually to write to memory
 ### Security
 
 

--- a/podaac/subsetter/subset.py
+++ b/podaac/subsetter/subset.py
@@ -1018,7 +1018,7 @@ def subset(file_to_subset: str, bbox: np.ndarray, output_file: str,
            # pylint: disable=too-many-branches, disable=too-many-statements
            cut: bool = True, shapefile: str = None, min_time: str = None, max_time: str = None,
            origin_source: str = None,
-           lat_var_names: List[str] = (), lon_var_names: List[str] = (), time_var_names: List[str] = (), test=False
+           lat_var_names: List[str] = (), lon_var_names: List[str] = (), time_var_names: List[str] = ()
            ) -> Union[np.ndarray, None]:
     """
     Subset a given NetCDF file given a bounding box
@@ -1189,8 +1189,8 @@ def subset(file_to_subset: str, bbox: np.ndarray, output_file: str,
                     data_var.load().to_netcdf(output_file, 'a', encoding={var: encoding.get(var)})
                     del data_var
 
-                with nc.Dataset(output_file, 'a') as ds:
-                    ds.setncatts(dataset.attrs)
+                with nc.Dataset(output_file, 'a') as dataset_attr:
+                    dataset_attr.setncatts(dataset.attrs)
 
         if has_groups:
             recombine_grouped_datasets(datasets, output_file, start_date)

--- a/podaac/subsetter/subset.py
+++ b/podaac/subsetter/subset.py
@@ -46,7 +46,6 @@ from podaac.subsetter.group_handling import GROUP_DELIM, transform_grouped_datas
     h5file_transform
 
 SERVICE_NAME = 'l2ss-py'
-MAX_MEM_USE = 1024 * 1024 * 1024 * 2 * .8
 
 
 def apply_scale_offset(scale: float, offset: float, value: float) -> float:

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -140,8 +140,7 @@ def test_subset_variables(test_file, data_dir, subset_output_dir, request):
     subset.subset(
         file_to_subset=join(data_dir, test_file),
         bbox=bbox,
-        output_file=join(subset_output_dir, output_file),
-        test=True
+        output_file=join(subset_output_dir, output_file)
     )
 
     in_ds = xr.open_dataset(join(data_dir, test_file),

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -140,7 +140,8 @@ def test_subset_variables(test_file, data_dir, subset_output_dir, request):
     subset.subset(
         file_to_subset=join(data_dir, test_file),
         bbox=bbox,
-        output_file=join(subset_output_dir, output_file)
+        output_file=join(subset_output_dir, output_file),
+        test=True
     )
 
     in_ds = xr.open_dataset(join(data_dir, test_file),


### PR DESCRIPTION
### Description

L2ss was running out of memory when trying to subset SMAP_RSS and CYGNSS collections

### Overview of work done

Loading dataset into memory and then writing to file used up a lot of memory. Make a deep copy of the dataset variable and load into memory then write to file. After writing to file delete the deep copy set. This seem to have free up the variable in memory after use and allow us to work within the 2GB we have for a container in harmony. It is still possible to go over the 2GB limit.

### Overview of verification done

Tested local harmony to make sure SMAP_RSS and CYGNSS was able to subset all variables

### Overview of integration done

Made sure all tests still passes

## PR checklist:

* [ ] Linted
* [ ] Updated unit tests
* [ ] Updated changelog
* [ ] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_