### PR TITLE
Feature/podaac 5537

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [issue/153](https://github.com/podaac/l2ss-py/issues/153): Remove the asc_node_tai93 variable when blank in the SNDR collections for xarray.decode_times to decode
 - PODAAC-5538: Reduce memory footprint of l2ss by loading each variable individually to write to memory
+- PODAAC-5537: Fixed AQUARIUS_L2_SSS_V5 dataset
 ### Security
 
 

--- a/podaac/subsetter/group_handling.py
+++ b/podaac/subsetter/group_handling.py
@@ -176,8 +176,6 @@ def _rename_variables(dataset: xr.Dataset, base_dataset: nc.Dataset, start_date)
             new_value = value.replace("/", "_") if isinstance(value, str) else value
             var_attrs[new_key] = new_value
 
-        #var_attrs = variable.attrs
-
         fill_value = var_attrs.get('_FillValue')
         var_attrs.pop('_FillValue', None)
         comp_args = {"zlib": True, "complevel": 1}

--- a/podaac/subsetter/group_handling.py
+++ b/podaac/subsetter/group_handling.py
@@ -170,7 +170,14 @@ def _rename_variables(dataset: xr.Dataset, base_dataset: nc.Dataset, start_date)
                 encoded_var = cf_dt_coder.encode(dataset.variables[var_name])
                 variable = encoded_var
 
-        var_attrs = variable.attrs
+        var_attrs = {}
+        for key, value in variable.attrs.items():
+            new_key = key.replace("/", "_") if isinstance(key, str) else key
+            new_value = value.replace("/", "_") if isinstance(value, str) else value
+            var_attrs[new_key] = new_value
+
+        #var_attrs = variable.attrs
+
         fill_value = var_attrs.get('_FillValue')
         var_attrs.pop('_FillValue', None)
         comp_args = {"zlib": True, "complevel": 1}

--- a/podaac/subsetter/subset.py
+++ b/podaac/subsetter/subset.py
@@ -978,12 +978,15 @@ def open_as_nc_dataset(filepath: str) -> Tuple[nc.Dataset, bool]:
         nc_dataset, has_groups = h5file_transform(filepath)
     else:
         # Open dataset with netCDF4 first, so we can get group info
-        nc_dataset = nc.Dataset(filepath, mode='r')
-        has_groups = bool(nc_dataset.groups)
+        try:
+            nc_dataset = nc.Dataset(filepath, mode='r')
+            has_groups = bool(nc_dataset.groups)
 
-        # If dataset has groups, transform to work with xarray
-        if has_groups:
-            nc_dataset = transform_grouped_dataset(nc_dataset, filepath)
+            # If dataset has groups, transform to work with xarray
+            if has_groups:
+                nc_dataset = transform_grouped_dataset(nc_dataset, filepath)
+        except Exception:
+            nc_dataset, has_groups = h5file_transform(filepath)
 
     nc_dataset = dc.remove_duplicate_dims(nc_dataset)
 

--- a/podaac/subsetter/subset.py
+++ b/podaac/subsetter/subset.py
@@ -985,7 +985,7 @@ def open_as_nc_dataset(filepath: str) -> Tuple[nc.Dataset, bool]:
             # If dataset has groups, transform to work with xarray
             if has_groups:
                 nc_dataset = transform_grouped_dataset(nc_dataset, filepath)
-        except Exception:
+        except OSError:
             nc_dataset, has_groups = h5file_transform(filepath)
 
     nc_dataset = dc.remove_duplicate_dims(nc_dataset)


### PR DESCRIPTION
### Description

-Fix AQUARIUS_L2_SSS_V5 dataset with l2ss

### Overview of work done

- Modify the way we open AQUARIUS_L2_SSS_V5, try with netcdf4 and if we can't try to use h5py
- Modify way we copy attributes, sometimes there is a "/" in the attributes, replace with _, problem when writing netcdf4 format file.

### Overview of verification done

Tested local harmony to make sure able to subset AQUARIUS_L2_SSS_V5

### Overview of integration done

_Explain how this change was integration tested. Provide screenshots or logs if appropriate. An example of this would be a local Harmony deployment._

## PR checklist:

* [ ] Linted
* [ ] Updated unit tests
* [ ] Updated changelog
* [ ] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_