### PR TITLE
update code to not remove "/" on attribute values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 ### Changed
+= [issue/182](https://github.com/podaac/l2ss-py/issues/182): Update code so doesn't remove '/' on attribute values.
 ### Deprecated 
 ### Removed
 ### Fixed

--- a/podaac/subsetter/group_handling.py
+++ b/podaac/subsetter/group_handling.py
@@ -173,8 +173,7 @@ def _rename_variables(dataset: xr.Dataset, base_dataset: nc.Dataset, start_date)
         var_attrs = {}
         for key, value in variable.attrs.items():
             new_key = key.replace("/", "_") if isinstance(key, str) else key
-            new_value = value.replace("/", "_") if isinstance(value, str) else value
-            var_attrs[new_key] = new_value
+            var_attrs[new_key] = value
 
         fill_value = var_attrs.get('_FillValue')
         var_attrs.pop('_FillValue', None)


### PR DESCRIPTION
Github Issue: #182 _(replace NUM with Github issue number)_

### Description

attributes with '/' are replaced with '_'. Units such as W/m^2 need to be conserved with the slash in the string. Coordinate attributes with slashes need to be conserved as well.

### Overview of work done

Update l2ss py so that we don't remove '/' from the attribute values

### Overview of verification done

Tested on aquarius on local harmony to make sure still subsets

### Overview of integration done


## PR checklist:

* [ ] Linted
* [ ] Updated unit tests
* [x] Updated changelog
* [ ] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_