### PR TITLE
Feature/issue 172

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - [issue/182](https://github.com/podaac/l2ss-py/issues/182): Update code so doesn't remove '/' on attribute values.
 - [issue/178](https://github.com/podaac/l2ss-py/issues/178): Add function to make sure dimension in subset is same as original file
+- [issue/172](https://github.com/podaac/l2ss-py/issues/178): Fix shapefile subsetting by passing correct variable to subset function.
 ### Deprecated 
 ### Removed
 ### Fixed

--- a/podaac/subsetter/subset_harmony.py
+++ b/podaac/subsetter/subset_harmony.py
@@ -136,7 +136,7 @@ class L2SubsetterService(BaseHarmonyAdapter):
                 harmony_bbox = message.subset.bbox
 
             if message.subset and message.subset.shape:
-                subset_params['shapefile_path'] = download(
+                subset_params['shapefile'] = download(
                     message.subset.shape.href,
                     temp_dir,
                     logger=self.logger,


### PR DESCRIPTION
Github Issue: #172 _(replace NUM with Github issue number)_

### Description

After some debugging, it seems like there is an issue with the L2SS service when ordering from Earthdata Search with a shapefile for subsetting. We have confirmed we are successfully passing a valid shapefile. When the request is made to Harmony we receive the following error:

WorkItem [16079488] failed with error: podaac/l2ss-py:2.4.0: Service request failed with an unknown error

Jira: PCESA-2733
### Overview of work done

Fix parameter passing into subset function from shapefile_path to shapefile 

### Overview of verification done

Looked into error log and see error is wrong parameter passed into function, don't have shapefile to test with harmony and earthdata search, will test in UAT

### Overview of integration done

_Explain how this change was integration tested. Provide screenshots or logs if appropriate. An example of this would be a local Harmony deployment._

## PR checklist:

* [ ] Linted
* [ ] Updated unit tests
* [ ] Updated changelog
* [ ] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_