### PR TITLE
Feature/issue 184

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 - [issue/119](https://github.com/podaac/l2ss-py/issues/119): GPM variable dimensions are renamed from "phony_dim" to the dimension names in the variable attribute "DimensionNames"
+- [issue/184](https://github.com/podaac/l2ss-py/issues/184): boundary box argument at the command line is changed to allow decimal numbers (i.e., floats) for coordinates
 ### Security
 
 

--- a/podaac/subsetter/run_subsetter.py
+++ b/podaac/subsetter/run_subsetter.py
@@ -35,7 +35,7 @@ def parse_args(args: list) -> tuple:
     )
     parser.add_argument(
         '--bbox',
-        type=int,
+        type=float,
         default=[-180, -90, 180, 90],
         nargs=4,
         action='store',

--- a/podaac/subsetter/xarray_enhancements.py
+++ b/podaac/subsetter/xarray_enhancements.py
@@ -54,7 +54,7 @@ def get_indexers_from_1d(cond: xr.Dataset) -> dict:
 
 def get_indexers_from_nd(cond: xr.Dataset, cut: bool) -> dict:
     """
-    Get indexers from a dataset with more than 1 dimensions.
+    Get indexers from a dataset with more than one dimension.
 
     Parameters
     ----------


### PR DESCRIPTION
Github Issue: #184 

### Description

Allow decimal numbers to be used for boundary box argument in the command line interface.

### Overview of work done

Changed the allowable type from `int` to `float`

### Overview of verification done

Ran an example subset at the command line to ensure that decimal numbers would be allowed.

### Overview of integration done

None.

## PR checklist:

* [X] Linted
* [N/A] Updated unit tests
* [x] Updated changelog
* [ ] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_