### PR TITLE
Feature/fix temporal subsetting ghrsst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [issue/267](https://github.com/podaac/l2ss-py/pull/261): Add xtrack and atrack dimension options for get_nd_indexers when bounding box subsetting is performed on SNDR.
 - Fix temporal subsetting ghrsst dataset by adding time delta to time variable.
+- Add a function to test ghrsst dataset ability to access variables when mask_and_scale is true. 
 ### Changed
 ### Deprecated 
 ### Removed

--- a/podaac/subsetter/subset.py
+++ b/podaac/subsetter/subset.py
@@ -1162,7 +1162,7 @@ def test_access_sst_dtime_values(datafile):
             # pylint: disable=pointless-statement
             dataset['sst_dtime'].values
             return True
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, KeyError):
         return False
 
 
@@ -1271,7 +1271,9 @@ def subset(file_to_subset: str, bbox: np.ndarray, output_file: str,
 
             if (getattr(time_var, '_FillValue', None) == fill_value_f8 and time_var.dtype in float_dtypes) or \
                (getattr(time_var, 'long_name', None) == "reference time of sst file"):
-                args['mask_and_scale'] = test_access_sst_dtime_values(file_to_subset)
+                args['mask_and_scale'] = True
+                if getattr(time_var, 'long_name', None) == "reference time of sst file":
+                    args['mask_and_scale'] = test_access_sst_dtime_values(file_to_subset)
                 break
 
     if hdf_type == 'GPM':

--- a/podaac/subsetter/subset.py
+++ b/podaac/subsetter/subset.py
@@ -1160,10 +1160,11 @@ def test_access_sst_dtime_values(datafile):
                 **args
         ) as dataset:
             # pylint: disable=pointless-statement
-            dataset['sst_dtime'].values
-            return True
+            for var_name in dataset.variables:
+                dataset[var_name].values
     except (TypeError, ValueError, KeyError):
         return False
+    return True
 
 
 def subset(file_to_subset: str, bbox: np.ndarray, output_file: str,


### PR DESCRIPTION
### Description

- Sometime when accessing sst_dtime variable in some collection we get an exception _scale_offset_decoding\r\n data *= scale_factor\r\nnumpy.core._exceptions._UFuncOutputCastingError: Cannot cast ufunc 'multiply' output from dtype('float64') to dtype('int64') with casting rule 'same_kind'\r\n`. Track down the problem when we set the mask_and_scale to true when opening the file.

### Overview of work done

- Add a new function to test the ability to use access the sst_dtime variable to determine if we should use mask_and_scale 

### Overview of verification done

- Tested temporal subsetting locally

### Overview of integration done

_Explain how this change was integration tested. Provide screenshots or logs if appropriate. An example of this would be a local Harmony deployment._

## PR checklist:

* [ ] Linted
* [ ] Updated unit tests
* [ ] Updated changelog
* [ ] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_