### PR TITLE
Handle OB.DAAC files, which do not have time variables

### DIFF
--- a/podaac/subsetter/subset.py
+++ b/podaac/subsetter/subset.py
@@ -560,6 +560,10 @@ def compute_time_variable_name(dataset: xr.Dataset, lat_var: xr.Variable, total_
         if var_name not in total_time_vars and 'time' in var_name_time.lower() and dataset[var_name].squeeze().dims[0] in lat_var.squeeze().dims:
             return var_name
 
+    # OB.DAAC data does not have a time variable. Returning the following field of a composite time value to avoid exceptions.
+    if '__scan_line_attributes__day' in dataset.data_vars:
+        return '__scan_line_attributes__day'
+
     raise ValueError('Unable to determine time variable')
 
 


### PR DESCRIPTION
Github Issue: #NUM _(replace NUM with Github issue number)_

### Description

Made minor changes in subset.py.
### Overview of work done

_Summarize the work you did_

Added two lines of code to void the "Unable to determine time variable" error  for data that has no time variable.

### Overview of verification done

_Summarize the testing and verification you've done. This includes unit tests or testing with specific data_

Tested the modified code with PACE data.

### Overview of integration done

_Explain how this change was integration tested. Provide screenshots or logs if appropriate. An example of this would be a local Harmony deployment._

Integration should be tested with two sets of data: data with a time variable, and data without a time variable.
## PR checklist:

* [ ] Linted
* [ ] Updated unit tests
* [ ] Updated changelog
* [ ] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_