### PR TITLE
Feature/fix cygnss collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Updated readme documentation
 ### Changed
+- Changed way Cygnss collection finds time variable
 ### Deprecated 
 ### Removed
 ### Fixed

--- a/podaac/subsetter/datatree_subset.py
+++ b/podaac/subsetter/datatree_subset.py
@@ -690,7 +690,10 @@ def compute_time_variable_name_tree(tree, lat_var, total_time_vars):
             if result:
                 # Normalize /sample_time to /solar_time for this unique case
                 if result == "/sample_time":
-                    return "/solar_time"
+                    # Check if '/solar_time' exists in the dataset
+                    if "/solar_time" in [f"/{v}" for v in ds.variables]:
+                        print('returning solar time')
+                        return "/solar_time"
                 return result
     return None
 


### PR DESCRIPTION
This pull request introduces improvements to documentation and modifies the handling of time variables in the Cygnss collection. The most notable change is the update to the logic that normalizes `/sample_time` to `/solar_time`, ensuring that `/solar_time` exists in the dataset before making the substitution.

Documentation updates:

* Updated the readme documentation to provide clearer information about the project.

Cygnss collection enhancements:

* Changed the method for finding the time variable in the Cygnss collection, specifically updating the logic in `method_6` to check for the existence of `/solar_time` before substituting for `/sample_time`. [[1]](diffhunk://#diff-3da95584a7e44c9e97ef9f4945a061bb70185fc5cc2c854ac7197d54d9d23b85R693-R695) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR9-R11)
