### PR TITLE
Resolve dimension name recovery for multiple swaths with same dim names, but different sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 - [issue/394] (https://github.com/podaac/l2ss-py/issues/394) Fixes HDF handling with datatree
+- [issue/394] (https://github.com/podaac/l2ss-py/issues/394) Update ODL parser to handle multi swath/grid collections
 ### Security
 
 

--- a/podaac/subsetter/utils/hdf_utils.py
+++ b/podaac/subsetter/utils/hdf_utils.py
@@ -131,12 +131,10 @@ def _find_scope_roots(dt: DataTree) -> list[DataTree]:
     """
     candidates = []
     for node in dt.subtree:
-        path = node.path.rstrip("/")
+        path = node.path.rstrip("/").casefold()
         if path in (
-            "/HDFEOS/SWATHS",
-            "/HDFEOS/GRIDS",
-            "/HDFEOS/Swaths",
-            "/HDFEOS/Grids",
+            "/hdfeos/swaths",
+            "/hdfeos/grids",
         ):
             candidates.extend(node.children.values())
     return candidates

--- a/podaac/subsetter/utils/hdf_utils.py
+++ b/podaac/subsetter/utils/hdf_utils.py
@@ -29,8 +29,10 @@ def _phony_index(dim: str) -> int:
 def rename_phony_dims(dt: DataTree) -> DataTree:
     """
     Return a new DataTree with all phony_dim_N dimensions renamed to
-    meaningful names.  The three strategies are tried in priority order;
-    the first one that produces a non-empty mapping is used.
+    meaningful names. First check if `DimensionNames` is present as
+    attributes for each variable otherwise check for `StructMeta.0`
+    and assuming an HDFEOS structure. the first one that produces a
+    non-empty mapping is used.
 
     Parameters
     ----------
@@ -98,34 +100,6 @@ def _mapping_from_dimension_names(dt: DataTree) -> dict[str, str]:
     return mapping
 
 
-def _mapping_from_struct_metadata(dt: DataTree) -> dict[str, str]:
-    """
-    Locate the StructMetadata.0 variable (typically at /HDFEOS
-    INFORMATION), parse its ODL (Object Description Language) content
-    to extract every named dimension and its size, then match those
-    against the phony dims in the tree by size.
-
-    Returns an empty dict if no StructMetadata.0 is found or parsing
-    fails.
-    """
-    struct_text = _find_struct_metadata(dt)
-    if not struct_text:
-        return {}
-
-    # parse named dimensions: {dim_name: size}
-    named_dims = _parse_odl_dimensions(struct_text)
-    if not named_dims:
-        return {}
-
-    # Build size -> name lookup. If two dims share a size we keep both and
-    # later rely on positional ordering within each group.
-    size_to_names: dict[int, list[str]] = defaultdict(list)
-    for name, size in named_dims.items():
-        size_to_names[size].append(name)
-
-    return _match_phony_to_named(dt, size_to_names, named_dims)
-
-
 def _find_struct_metadata(dt: DataTree) -> str | None:
     """Return the decoded text of StructMetadata.0 if present anywhere
     in the tree.
@@ -149,31 +123,111 @@ def _find_struct_metadata(dt: DataTree) -> str | None:
     return None
 
 
-def _parse_odl_dimensions(odl_text: str) -> dict[str, int]:
+def _find_scope_roots(dt: DataTree) -> list[DataTree]:
     """
-    Extract all ``DimensionName`` / ``Size`` pairs from an ODL
-    metadata block.
-
-    ODL blocks look like
-
-        OBJECT=Dimension_1
-            DimensionName="nTimes"
-            Size=1496
-        END_OBJECT=Dimension_1
+    Return the immediate children of /HDFEOS/SWATHS or /HDFEOS/GRIDS.
+    These represent individual swaths / grids and are the correct scopes
+    within which phony dims should be unified.
     """
-    named_dims: dict[str, int] = {}
+    candidates = []
+    for node in dt.subtree:
+        path = node.path.rstrip("/")
+        if path in (
+            "/HDFEOS/SWATHS",
+            "/HDFEOS/GRIDS",
+            "/HDFEOS/Swaths",
+            "/HDFEOS/Grids",
+        ):
+            candidates.extend(node.children.values())
+    return candidates
 
-    # split on END_OBJECT boundaries so we can parse each object block
-    blocks = re.split(r"END_OBJECT\s*=\s*\w+", odl_text)
-    for block in blocks:
-        dim_name_match = re.search(r'DimensionName\s*=\s*"([^"]+)"', block)
-        size_match = re.search(r"\bSize\s*=\s*(\d+)", block)
-        if dim_name_match and size_match:
-            name = dim_name_match.group(1).strip()
-            size = int(size_match.group(1))
-            named_dims[name] = size
 
-    return named_dims
+def _parse_odl_scope_dimensions(odl_text: str) -> dict[str, dict[str, int]]:
+    """
+    Parse the ODL block and return a per-scope dimension mapping:
+        {scope_name: {dim_name: size}}
+
+    Handles both SwathStructure (SWATH_N / SwathName) and GridStructure
+    (GRID_N / GridName) blocks. Each scope is parsed independently so that
+    two scopes sharing a dimension name but with different sizes never
+    overwrite each other.
+    """
+    result: dict[str, dict[str, int]] = {}
+
+    # split on any SWATH_N or GRID_N end-group boundary
+    scope_blocks = re.split(r"END_GROUP\s*=\s*(?:SWATH|GRID)_\d+", odl_text)
+
+    for block in scope_blocks:
+        name_match = re.search(r'(?:SwathName|GridName)\s*=\s*"([^"]+)"', block)
+        if not name_match:
+            continue
+        scope_name = name_match.group(1).strip()
+
+        dim_group_match = re.search(
+            r"GROUP\s*=\s*Dimension(.+?)END_GROUP\s*=\s*Dimension",
+            block,
+            re.DOTALL,
+        )
+        if not dim_group_match:
+            continue
+
+        named_dims: dict[str, int] = {}
+        for obj_block in re.split(
+            r"END_OBJECT\s*=\s*Dimension_\d+", dim_group_match.group(1)
+        ):
+            dim_name_match = re.search(r'DimensionName\s*=\s*"([^"]+)"', obj_block)
+            size_match = re.search(r"\bSize\s*=\s*(\d+)", obj_block)
+            if dim_name_match and size_match:
+                named_dims[dim_name_match.group(1).strip()] = int(size_match.group(1))
+
+        if named_dims:
+            result[scope_name] = named_dims
+
+    return result
+
+
+def _mapping_from_struct_metadata(dt: DataTree) -> dict[str, str]:
+    """
+    Locate the StructMetadata.0 variable (typically at /HDFEOS
+    INFORMATION), parse its ODL (Object Description Language) content
+    to extract every named dimension and its size, then match those
+    against the phony dims in the tree by size.
+
+    Returns an empty dict if no StructMetadata.0 is found or parsing
+    fails.
+    """
+    struct_text = _find_struct_metadata(dt)
+    if not struct_text:
+        return {}
+
+    swath_dims = _parse_odl_scope_dimensions(struct_text)
+    if not swath_dims:
+        return {}
+
+    mapping: dict[str, str] = {}
+
+    scope_roots = _find_scope_roots(dt)
+    if not scope_roots:
+        scope_roots = [dt]
+
+    for scope_root in scope_roots:
+        # extract the swath name from the path, e.g.
+        # "/HDFEOS/SWATHS/OMI Ground Pixel Corners UV-1" -> "OMI Ground Pixel Corners UV-1"
+        swath_name = scope_root.path.rstrip("/").split("/")[-1]
+        named_dims = swath_dims.get(swath_name)
+
+        if not named_dims:
+            # swath name not found in ODL
+            continue
+
+        size_to_names: dict[int, list[str]] = defaultdict(list)
+        for name, size in named_dims.items():
+            size_to_names[size].append(name)
+
+        scope_mapping = _match_phony_to_named(scope_root, size_to_names, named_dims)
+        mapping.update(scope_mapping)
+
+    return mapping
 
 
 def _match_phony_to_named(

--- a/tests/test_hdf_phony_dims.py
+++ b/tests/test_hdf_phony_dims.py
@@ -1,7 +1,6 @@
 import xarray as xr
-from xarray import DataTree
-
 from podaac.subsetter.utils.hdf_utils import rename_phony_dims
+from xarray import DataTree
 
 
 def make_tree(groups: dict[str, xr.Dataset]) -> DataTree:
@@ -94,8 +93,7 @@ def test_struct_metadata_renames_dims():
     odl = (
         "GROUP=SwathStructure\n"
         "GROUP=SWATH_1\n"
-        "GROUP=DimensionMap\n"
-        "END_GROUP=DimensionMap\n"
+        'SwathName="MySWATH\n"'
         "GROUP=Dimension\n"
         "OBJECT=Dimension_1\n"
         'DimensionName="nTimes"\n'
@@ -106,6 +104,8 @@ def test_struct_metadata_renames_dims():
         "Size=60\n"
         "END_OBJECT=Dimension_2\n"
         "END_GROUP=Dimension\n"
+        "GROUP=DimensionMap\n"
+        "END_GROUP=DimensionMap\n"
         "END_GROUP=SWATH_1\n"
         "END_GROUP=SwathStructure\n"
     )
@@ -122,6 +122,116 @@ def test_struct_metadata_renames_dims():
     )
     result = rename_phony_dims(dt)
     dims = result["/HDFEOS/SWATHS/MySWATH/Data Fields"].ds["ColumnAmount"].dims
+    assert dims == ("nTimes", "nXtrack")
+
+
+def test_struct_metadata_renames_dims_multi_swath():
+    # note(ocs): this type of multi swatch structure occurs in collections like OMPIXCOR_003
+    odl = (
+        "GROUP=SwathStructure\n"
+        "GROUP=SWATH_1\n"
+        'SwathName="MySWATH\n"'
+        "GROUP=Dimension\n"
+        "OBJECT=Dimension_1\n"
+        'DimensionName="nTimes"\n'
+        "Size=1496\n"
+        "END_OBJECT=Dimension_1\n"
+        "OBJECT=Dimension_2\n"
+        'DimensionName="nXtrack"\n'
+        "Size=60\n"
+        "END_OBJECT=Dimension_2\n"
+        "END_GROUP=Dimension\n"
+        "GROUP=DimensionMap\n"
+        "END_GROUP=DimensionMap\n"
+        "END_GROUP=SWATH_1\n"
+        # start of swath 2
+        "GROUP=SWATH_2\n"
+        'SwathName="MySWATH2\n"'
+        "GROUP=Dimension\n"
+        "OBJECT=Dimension_1\n"
+        'DimensionName="nTimes"\n'
+        "Size=1496\n"
+        "END_OBJECT=Dimension_1\n"
+        "OBJECT=Dimension_2\n"
+        'DimensionName="nXtrack"\n'
+        # this nXtrack size is different in swath 2
+        "Size=30\n"
+        "END_OBJECT=Dimension_2\n"
+        "END_GROUP=Dimension\n"
+        "END_GROUP=SWATH_2\n"
+        "END_GROUP=SwathStructure\n"
+    )
+    struct_da = xr.DataArray(odl)
+    da = xr.DataArray(
+        [[1.0] * 60] * 1496,
+        dims=[phony(0), phony(1)],
+    )
+
+    da2 = xr.DataArray(
+        [[1.0] * 30] * 1496,
+        dims=[phony(0), phony(1)],
+    )
+    dt = make_tree(
+        {
+            "/HDFEOS INFORMATION": xr.Dataset({"StructMetadata.0": struct_da}),
+            "/HDFEOS/SWATHS/MySWATH/Data Fields": xr.Dataset({"ColumnAmount": da}),
+            "/HDFEOS/SWATHS/MySWATH2/Data Fields": xr.Dataset({"ColumnAmount": da2}),
+        }
+    )
+    result = rename_phony_dims(dt)
+    swath1_dims = result["/HDFEOS/SWATHS/MySWATH/Data Fields"].ds["ColumnAmount"].dims
+    swath2_dims = result["/HDFEOS/SWATHS/MySWATH2/Data Fields"].ds["ColumnAmount"].dims
+
+    # have the names been recovered?
+    assert swath1_dims == ("nTimes", "nXtrack")
+    assert swath2_dims == ("nTimes", "nXtrack")
+
+    swath1_dim_shape = (
+        result["/HDFEOS/SWATHS/MySWATH/Data Fields"].ds["ColumnAmount"].shape
+    )
+    swath2_dim_shape = (
+        result["/HDFEOS/SWATHS/MySWATH2/Data Fields"].ds["ColumnAmount"].shape
+    )
+
+    # are dimensions in differnet swaths, with different sizes but
+    # same name matched correctly?
+    assert swath1_dim_shape == (1496, 60)
+    assert swath2_dim_shape == (1496, 30)
+
+
+def test_struct_grid_metadata_renames_dims():
+    odl = (
+        "GROUP=GridStructure\n"
+        "GROUP=GRID_1\n"
+        'SwathName="MyGRID\n"'
+        "GROUP=Dimension\n"
+        "OBJECT=Dimension_1\n"
+        'DimensionName="nTimes"\n'
+        "Size=1496\n"
+        "END_OBJECT=Dimension_1\n"
+        "OBJECT=Dimension_2\n"
+        'DimensionName="nXtrack"\n'
+        "Size=60\n"
+        "END_OBJECT=Dimension_2\n"
+        "END_GROUP=Dimension\n"
+        "GROUP=DimensionMap\n"
+        "END_GROUP=DimensionMap\n"
+        "END_GROUP=GRID_1\n"
+        "END_GROUP=GridStructure\n"
+    )
+    struct_da = xr.DataArray(odl)
+    da = xr.DataArray(
+        [[1.0] * 60] * 1496,
+        dims=[phony(0), phony(1)],
+    )
+    dt = make_tree(
+        {
+            "/HDFEOS INFORMATION": xr.Dataset({"StructMetadata.0": struct_da}),
+            "/HDFEOS/GRIDS/MyGRID/Data Fields": xr.Dataset({"ColumnAmount": da}),
+        }
+    )
+    result = rename_phony_dims(dt)
+    dims = result["/HDFEOS/GRIDS/MyGRID/Data Fields"].ds["ColumnAmount"].dims
     assert dims == ("nTimes", "nXtrack")
 
 


### PR DESCRIPTION
Github Issue: #394

### Description

Some collections like OMPIXCOR_003 contain multiple swaths with the same dimension names assigned to variables, but with different sizes. This would throw off the current dimension mapping implementation. 

### Overview of work done

Update ODL parser to track multiple dim sizes for a given dimension and parse on a scope basis instead of just assuming single swath group. 

### Overview of verification done

Validated with OMPIXCOR_003 data locally, added tests which mirror multi swath and grid structure to validate and catch. 

## PR checklist:

* [X] Linted
* [X] Updated unit tests
* [X] Updated changelog
* [X] Integration testing