### PR TITLE
Handle NetCDF with ScanTime swath group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated readme documentation
 ### Changed
 - Changed way Cygnss collection finds time variable
-### Deprecated 
+### Deprecated
 ### Removed
 ### Fixed
 - [issue/394] (https://github.com/podaac/l2ss-py/issues/394) Fixes HDF handling with datatree
 - [issue/394] (https://github.com/podaac/l2ss-py/issues/394) Update ODL parser to handle multi swath/grid collections
+- [issue/396] (https://github.com/podaac/l2ss-py/issues/396) Handle new GPM v08 collections with netcdf format, but still containing wonky ScanTime swath group
 ### Security
 
 

--- a/podaac/subsetter/subset.py
+++ b/podaac/subsetter/subset.py
@@ -323,7 +323,8 @@ def subset(file_to_subset: str, bbox: np.ndarray, output_file: str,
     file_extension = os.path.splitext(file_to_subset)[1]
     file_utils.override_decode_cf_datetime()
 
-    hdf_type = False
+    hdf_type = ""
+    scantime_present = False
 
     args = {
         'decode_coords': False,
@@ -334,6 +335,9 @@ def subset(file_to_subset: str, bbox: np.ndarray, output_file: str,
     with xr.open_datatree(file_to_subset, **args) as dataset:
         if file_extension.lower() in _HDF_EXTENSIONS:
             hdf_type = file_utils.get_hdf_type(dataset)
+            scantime_present = hdf_type == "GPM"
+        else:
+            scantime_present = file_utils.has_scantime(dataset)
 
     if min_time or max_time:
         fill_value_f8 = nc.default_fillvals.get('f8')
@@ -353,7 +357,9 @@ def subset(file_to_subset: str, bbox: np.ndarray, output_file: str,
         except Exception:  # pylint: disable=broad-exception-caught
             pass
 
-    if hdf_type == 'GPM':
+    # set decodetimes to false if "GPM" hdf, or if netcdf has
+    # scantime present (e.g. GPM v08)
+    if hdf_type == 'GPM' or scantime_present:
         args['decode_times'] = False
 
     time_encoding = {}
@@ -409,9 +415,9 @@ def subset(file_to_subset: str, bbox: np.ndarray, output_file: str,
             time_var_names=time_var_names
         )
 
-        # note(ocs): I believe this only applies to GPM, but checking
-        #            against general hdf until certain
-        if hdf_type:
+        # assumption is that GPM HDFEOS or GPM V08+ NetCDF4 will have
+        # scantime.
+        if hdf_type == "GPM" or scantime_present:
             new_time_var_names = []
             for group in dataset.groups:
                 if "ScanTime" in group:

--- a/podaac/subsetter/subset.py
+++ b/podaac/subsetter/subset.py
@@ -416,7 +416,7 @@ def subset(file_to_subset: str, bbox: np.ndarray, output_file: str,
 
         # assumption is that GPM HDFEOS or GPM V08+ NetCDF4 will have
         # scantime.
-        if hdf_type == "GPM" or scantime_present:
+        if scantime_present:
             new_time_var_names = []
             for group in dataset.groups:
                 if "ScanTime" in group:

--- a/podaac/subsetter/subset.py
+++ b/podaac/subsetter/subset.py
@@ -357,9 +357,8 @@ def subset(file_to_subset: str, bbox: np.ndarray, output_file: str,
         except Exception:  # pylint: disable=broad-exception-caught
             pass
 
-    # set decodetimes to false if "GPM" hdf, or if netcdf has
-    # scantime present (e.g. GPM v08)
-    if hdf_type == 'GPM' or scantime_present:
+    # set decode_times to false if scantime present (e.g. GPM)
+    if scantime_present:
         args['decode_times'] = False
 
     time_encoding = {}

--- a/podaac/subsetter/utils/file_utils.py
+++ b/podaac/subsetter/utils/file_utils.py
@@ -77,10 +77,8 @@ def get_hdf_type(tree: DataTree) -> Optional[str]:
     Determine the HDF type (OMI, MLS, or GPM) from a DataTree object.
     """
     try:
-        # GPM
-        for group in tree.groups:
-            if "ScanTime" in group:
-                return 'GPM'
+        if has_scantime(tree):
+            return 'GPM'
 
         # try to get types from instrument name
         additional_attrs = tree['/HDFEOS/ADDITIONAL/FILE_ATTRIBUTES']
@@ -104,3 +102,8 @@ def get_path(s):
     """Extracts the path by removing the last part after the final '/'."""
     path = s.rsplit('/', 1)[0] if '/' in s else s
     return path if path.startswith('/') else f'/{path}'
+
+
+def has_scantime(dataset: DataTree) -> bool:
+    """Check if "ScanTime" group present in dataset"""
+    return any("ScanTime" in group for group in dataset.groups)

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -1806,6 +1806,261 @@ def test_subset_gpm_compute_new_var_data(fake_gpm_file, data_dir, subset_output_
         if "ScanTime" in group:
             assert int(dtree[group].ds.variables["timeMidScan"][:][0]) == 1306403820
 
+
+@pytest.fixture(scope="session")
+def fake_gpm_mhs_file(tmp_path_factory):
+    """
+    Creates fake data following structure of GPM_2AGPROFMETOPBMHS_08
+    which has a netcdf4 format as opposed to HDF5EOS like previous
+    iterations of GPM products.
+
+    Specifically based off 2A.METOPB.MHS.GPROFNNv1.20260228-S233156-E011316.069788.V08A.nc
+    """
+    filepath = tmp_path_factory.mktemp("data") / "fake_mhs.nc"
+
+    nscan = 10
+    npixel = 5
+    nlyrs = 5
+
+    # root + global attributes
+    root_dict = {
+        "attrs": {
+            "FileHeader": "DOI=10.5067/GPM/MHS/METOPB/GPROF/2A/08;\nAlgorithmID=2AGPROFMHS;",
+            "InputRecord": "InputFileNames=1C.METOPB.MHS.XCAL2016.nc;",
+            "NavigationRecord": "LongitudeOnEquator=-44.554371;",
+            "FileInfo": "DataFormatVersion=8b;",
+            "GprofInfo": "Satellite=METOPB;Sensor=MHS;",
+        },
+        "dims": {},
+        "coords": {},
+        "data_vars": {},
+    }
+    xr.Dataset.from_dict(root_dict).to_netcdf(filepath, mode="w", engine="netcdf4")
+
+    # GprofDHeadr group containing the layer heights
+    headr_dict = {
+        "attrs": {},
+        "dims": {"nlyrs": nlyrs},
+        "coords": {},
+        "data_vars": {
+            "hgtTopLayer": {
+                "dims": ("nlyrs",),
+                "data": np.arange(nlyrs, dtype=np.float32),
+                "attrs": {"DimensionNames": "nlyrs", "Units": "km"},
+            }
+        },
+    }
+    xr.Dataset.from_dict(headr_dict).to_netcdf(
+        filepath, mode="a", group="GprofDHeadr", engine="netcdf4"
+    )
+
+    # primary swath variables (but only a few)
+    s1_dict = {
+        "attrs": {"SwathHeader": "NumberScansInSet=1;\nNumberPixels=90;"},
+        "dims": {"nscan": nscan, "npixel": npixel, "nlyrs": nlyrs},
+        "coords": {},
+        "data_vars": {
+            "Latitude": {
+                "dims": ("nscan", "npixel"),
+                "data": np.linspace(-90, 90, nscan * npixel)
+                .reshape(nscan, npixel)
+                .astype(np.float32),
+                "attrs": {"DimensionNames": "nscan,npixel", "Units": "degrees"},
+            },
+            "Longitude": {
+                "dims": ("nscan", "npixel"),
+                "data": np.linspace(-180, 180, nscan * npixel)
+                .reshape(nscan, npixel)
+                .astype(np.float32),
+                "attrs": {"DimensionNames": "nscan,npixel", "Units": "degrees"},
+            },
+            "surfacePrecipitation": {
+                "dims": ("nscan", "npixel"),
+                "data": np.linspace(0, 50, nscan * npixel)
+                .reshape(nscan, npixel)
+                .astype(np.float32),
+                "attrs": {"DimensionNames": "nscan,npixel", "Units": "mm/hr"},
+            },
+            "sunGlintAngle": {
+                "dims": ("nscan", "npixel"),
+                "data": np.linspace(0, 180, nscan * npixel)
+                .reshape(nscan, npixel)
+                .astype(np.float32),
+                "attrs": {"DimensionNames": "nscan,npixel", "Units": "degrees"},
+            },
+            "rainWaterContent": {
+                "dims": ("nscan", "npixel", "nlyrs"),
+                "data": np.linspace(0, 10, nscan * npixel * nlyrs)
+                .reshape(nscan, npixel, nlyrs)
+                .astype(np.float32),
+                "attrs": {"DimensionNames": "nscan,npixel,nlyrs", "Units": "g/m3"},
+            },
+        },
+    }
+    xr.Dataset.from_dict(s1_dict).to_netcdf(
+        filepath, mode="a", group="S1", engine="netcdf4"
+    )
+
+    # scantime subgroup is nested under S1 containing temporal variables
+    scantime_dict = {
+        "attrs": {},
+        "dims": {"nscan": nscan},
+        "coords": {},
+        "data_vars": {
+            "Year": {
+                "dims": ("nscan",),
+                "data": np.full(nscan, 2026, dtype=np.int16),
+                "attrs": {
+                    "DimensionNames": "nscan",
+                    "Units": "years",
+                    "_FillValue": -9999,
+                    "CodeMissingValue": "-9999",
+                },
+            },
+            "Month": {
+                "dims": ("nscan",),
+                "data": np.full(nscan, 2, dtype=np.int8),
+                "attrs": {
+                    "DimensionNames": "nscan",
+                    "Units": "months",
+                    "_FillValue": -99,
+                    "CodeMissingValue": "-99",
+                },
+            },
+            "DayOfMonth": {
+                "dims": ("nscan",),
+                "data": np.full(nscan, 28, dtype=np.int8),
+                "attrs": {
+                    "DimensionNames": "nscan",
+                    "Units": "days",
+                    "_FillValue": -99,
+                    "CodeMissingValue": "-99",
+                },
+            },
+            "Hour": {
+                "dims": ("nscan",),
+                "data": np.full(nscan, 23, dtype=np.int8),
+                "attrs": {
+                    "DimensionNames": "nscan",
+                    "Units": "hours",
+                    "_FillValue": -99,
+                    "CodeMissingValue": "-99",
+                },
+            },
+            "Minute": {
+                "dims": ("nscan",),
+                "data": np.full(nscan, 31, dtype=np.int8),
+                "attrs": {
+                    "DimensionNames": "nscan",
+                    "Units": "minutes",
+                    "_FillValue": -99,
+                    "CodeMissingValue": "-99",
+                },
+            },
+            "Second": {
+                "dims": ("nscan",),
+                "data": np.full(nscan, 56, dtype=np.int8),
+                "attrs": {
+                    "DimensionNames": "nscan",
+                    "Units": "s",
+                    "_FillValue": -99,
+                    "CodeMissingValue": "-99",
+                },
+            },
+            "MilliSecond": {
+                "dims": ("nscan",),
+                "data": np.full(nscan, 0, dtype=np.int16),
+                "attrs": {
+                    "DimensionNames": "nscan",
+                    "Units": "ms",
+                    "_FillValue": -9999,
+                    "CodeMissingValue": "-9999",
+                },
+            },
+            "DayOfYear": {
+                "dims": ("nscan",),
+                "data": np.full(nscan, 59, dtype=np.int16),
+                "attrs": {
+                    "DimensionNames": "nscan",
+                    "Units": "days",
+                    "_FillValue": -9999,
+                    "CodeMissingValue": "-9999",
+                },
+            },
+            "SecondOfDay": {
+                "dims": ("nscan",),
+                "data": np.linspace(84716.0, 84726.0, nscan).astype(np.float64),
+                "attrs": {
+                    "DimensionNames": "nscan",
+                    "Units": "s",
+                    "_FillValue": -9999.9,
+                    "CodeMissingValue": "-9999.9",
+                },
+            },
+        },
+    }
+    xr.Dataset.from_dict(scantime_dict).to_netcdf(
+        filepath, mode="a", group="S1/ScanTime", engine="netcdf4"
+    )
+
+    # SCstatus subgroup nested under S1
+    scstatus_dict = {
+        "attrs": {},
+        "dims": {"nscan": nscan},
+        "coords": {},
+        "data_vars": {
+            "SCaltitude": {
+                "dims": ("nscan",),
+                "data": np.full(nscan, 400.0, dtype=np.float32),
+                "attrs": {"DimensionNames": "nscan", "Units": "km"},
+            }
+        },
+    }
+    xr.Dataset.from_dict(scstatus_dict).to_netcdf(
+        filepath, mode="a", group="S1/SCstatus", engine="netcdf4"
+    )
+
+    return filepath
+
+
+def test_subset_gpm_mhs_compute_new_var_data(fake_gpm_mhs_file, subset_output_dir):
+    """
+    Tests that a GPM v08 file with NetCDF4 format can run through subset and produce correct variables
+    """
+
+    subset_output_file = Path(subset_output_dir) / "mhs_test_subset.nc"
+
+    # perform the subsetting operation on the fake data, make sure to
+    # keep created timeMidScan var created by l2ss to compare
+    subset.subset(
+        file_to_subset=fake_gpm_mhs_file,
+        bbox=np.array(((-90.1, 90.1), (-45.1, 45.1))),
+        variables=[
+            "S1/surfacePrecipitation",
+            "S1/ScanTime/timeMidScan",
+        ],
+        output_file=subset_output_file,
+        cut=True,
+    )
+    dtree = xr.open_datatree(subset_output_file)
+
+    # are /only/ the requested variables + neccisary location data present?
+    assert set(dtree["S1"].variables) == {
+        "surfacePrecipitation",
+        "Latitude",
+        "Longitude",
+    }
+    assert "timeMidScan" in dtree["S1/ScanTime"].variables
+
+    # are the requested variables dims the correct size?
+    assert dtree["S1/Latitude"].shape == (6, 5)
+    assert dtree["S1/Longitude"].shape == (6, 5)
+    assert dtree["S1/surfacePrecipitation"].shape == (6, 5)
+
+    # timeMidScan created, and correct?
+    assert int(dtree["S1/ScanTime"].variables["timeMidScan"][0]) == 1456356716
+
+
 def test_temporal_subset_tempo(data_dir, subset_output_dir, request):
 
     tempo_file = "TEMPO_HCHO_L2_V01_20240110T170237Z_S005G08.nc"


### PR DESCRIPTION
Github Issue: #396 

### Description
Fixes #396. 

Latest GPM v08 collections are no longer in HDF5EOS format, but are instead netcdf. However they still contain the wonky ScanTime swath group. Previous checks for this and creation of single timeMidScan variable assumed this only occurred in HDF files.  

### Overview of work done

Update checks for ScanTime to occur for all file formats as opposed for only HDF files. If ScanTime is present, compute timeMidScan regardless of format. 

Added unit test and fake data fixture which mirrors existing structure of GPM V08.

### Overview of verification done

Unit tests passing, validated against GPM_2AGPROFMETOPBMHS_08, OMCLODG_004, OMPIXCOR_003, GPM_2AGPROFNPPATMS_CLIM_07. 

## PR checklist:

* [X] Linted
* [X] Updated unit tests
* [X] Updated changelog
* [X] Integration testing