### PR TITLE
feature/odl parsing for hdf files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [issue/394] (https://github.com/podaac/l2ss-py/issues/394) Update ODL parser to handle multi swath/grid collections
 - [issue/396] (https://github.com/podaac/l2ss-py/issues/396) Handle new GPM v08 collections with netcdf format, but still containing wonky ScanTime swath group
 - [issue/400] (https://github.com/podaac/l2ss-py/issues/400) Fixed temporal subsetting for MOPITT collections
+- [issue/394] (https://github.com/podaac/l2ss-py/issues/394) Update ODL parser to apply direct mapping from DataField and GeoField objects
 ### Security
 
 

--- a/podaac/subsetter/utils/hdf_utils.py
+++ b/podaac/subsetter/utils/hdf_utils.py
@@ -13,6 +13,12 @@ import numpy as np
 import xarray as xr
 from xarray import DataTree
 
+_PHONY_RE = re.compile(r"^phony_dim_(\d+)$")
+
+
+def _is_phony(dim: str) -> bool:
+    return _PHONY_RE.match(dim) is not None
+
 
 def rename_phony_dims(dt: DataTree) -> DataTree:
     """
@@ -75,6 +81,10 @@ def _mapping_from_dimension_names(dt: DataTree) -> dict[str, str]:
                 continue
 
             for phony, real in zip(da.dims, real_names):
+                # guard for incorrectly specified HDFEOS data
+                # which might not have phony_dims being populated
+                if not _is_phony(phony):
+                    continue
                 existing = mapping.get(phony)
                 if existing is not None and existing != real:
                     # if two variables disagree on what this phony dim
@@ -235,6 +245,10 @@ def _apply_from_field_dimlists(
                 if odl_dims is None or len(odl_dims) != len(da.dims):
                     continue
                 for current_dim, real_name in zip(da.dims, odl_dims):
+                    # guard for incorrectly specified HDFEOS data
+                    # which might not have phony_dims being populated
+                    if not _is_phony(current_dim):
+                        continue
                     existing = local_mapping.get(current_dim)
                     if existing is not None and existing != real_name:
                         warnings.warn(

--- a/podaac/subsetter/utils/hdf_utils.py
+++ b/podaac/subsetter/utils/hdf_utils.py
@@ -8,22 +8,10 @@ Utility functions for handling HDF files, and dimension recovery
 
 import re
 import warnings
-from collections import defaultdict
 
 import numpy as np
 import xarray as xr
 from xarray import DataTree
-
-_PHONY_RE = re.compile(r"^phony_dim_(\d+)$")
-
-
-def _is_phony(dim: str) -> bool:
-    return _PHONY_RE.match(dim) is not None
-
-
-def _phony_index(dim: str) -> int:
-    m = _PHONY_RE.match(dim)
-    return int(m.group(1)) if m else -1
 
 
 def rename_phony_dims(dt: DataTree) -> DataTree:
@@ -45,14 +33,17 @@ def rename_phony_dims(dt: DataTree) -> DataTree:
         A new tree with renamed dimensions.
     """
     mapping = _mapping_from_dimension_names(dt)
+    if mapping:
+        dt = _apply_mapping(dt, mapping)
 
-    if not mapping:
-        mapping = _mapping_from_struct_metadata(dt)
+    struct_text = _find_struct_metadata(dt)
+    if struct_text:
+        scope_field_dimlists = _parse_odl_field_dimlists(struct_text)
+        if scope_field_dimlists:
+            dt = _apply_from_field_dimlists(dt, scope_field_dimlists)
 
-    if not mapping:
-        return dt
-
-    return _apply_mapping(dt, mapping)
+    # null condition
+    return dt
 
 
 def _mapping_from_dimension_names(dt: DataTree) -> dict[str, str]:
@@ -84,8 +75,6 @@ def _mapping_from_dimension_names(dt: DataTree) -> dict[str, str]:
                 continue
 
             for phony, real in zip(da.dims, real_names):
-                if not _is_phony(phony):
-                    continue
                 existing = mapping.get(phony)
                 if existing is not None and existing != real:
                     # if two variables disagree on what this phony dim
@@ -111,7 +100,6 @@ def _find_struct_metadata(dt: DataTree) -> str | None:
         for var_name in ds.data_vars:
             if "StructMetadata" in var_name:
                 raw = ds[var_name].values
-                # may be bytes, numpy bytes_, or already a string
                 if isinstance(raw, (bytes, np.bytes_)):
                     return raw.decode("utf-8", errors="replace")
                 if hasattr(raw, "item"):
@@ -140,19 +128,18 @@ def _find_scope_roots(dt: DataTree) -> list[DataTree]:
     return candidates
 
 
-def _parse_odl_scope_dimensions(odl_text: str) -> dict[str, dict[str, int]]:
+def _parse_odl_field_dimlists(odl_text: str) -> dict[str, dict[str, list[str]]]:
     """
-    Parse the ODL block and return a per-scope dimension mapping:
-        {scope_name: {dim_name: size}}
+    Parse the ODL block and return a per-scope, per-field dim list:
+        {scope_name: {field_name: [dim_name, ...]}}
 
     Handles both SwathStructure (SWATH_N / SwathName) and GridStructure
-    (GRID_N / GridName) blocks. Each scope is parsed independently so that
-    two scopes sharing a dimension name but with different sizes never
-    overwrite each other.
+    (GRID_N / GridName) blocks. The DimList order matches the axis
+    order of the variable as stored in the file, so it can be zipped
+    directly against the variable's actual (phony) dims.
     """
-    result: dict[str, dict[str, int]] = {}
+    result: dict[str, dict[str, list[str]]] = {}
 
-    # split on any SWATH_N or GRID_N end-group boundary
     scope_blocks = re.split(r"END_GROUP\s*=\s*(?:SWATH|GRID)_\d+", odl_text)
 
     for block in scope_blocks:
@@ -160,125 +147,33 @@ def _parse_odl_scope_dimensions(odl_text: str) -> dict[str, dict[str, int]]:
         if not name_match:
             continue
         scope_name = name_match.group(1).strip()
+        field_dimlists: dict[str, list[str]] = {}
 
-        dim_group_match = re.search(
-            r"GROUP\s*=\s*Dimension(.+?)END_GROUP\s*=\s*Dimension",
-            block,
-            re.DOTALL,
-        )
-        if not dim_group_match:
-            continue
+        # GeoField and DataField blocks both use the same OBJECT structure
+        for field_block in re.split(r"END_OBJECT\s*=\s*(?:Geo|Data)Field_\d+", block):
+            field_name_match = re.search(
+                r'(?:GeoFieldName|DataFieldName)\s*=\s*"([^"]+)"', field_block
+            )
+            dimlist_match = re.search(r"DimList\s*=\s*\(([^)]+)\)", field_block)
+            if not field_name_match or not dimlist_match:
+                continue
 
-        named_dims: dict[str, int] = {}
-        for obj_block in re.split(
-            r"END_OBJECT\s*=\s*Dimension_\d+", dim_group_match.group(1)
-        ):
-            dim_name_match = re.search(r'DimensionName\s*=\s*"([^"]+)"', obj_block)
-            size_match = re.search(r"\bSize\s*=\s*(\d+)", obj_block)
-            if dim_name_match and size_match:
-                named_dims[dim_name_match.group(1).strip()] = int(size_match.group(1))
+            field_name = field_name_match.group(1).strip()
+            dim_names = [
+                d.strip().strip('"') for d in dimlist_match.group(1).split(",")
+            ]
+            field_dimlists[field_name] = dim_names
 
-        if named_dims:
-            result[scope_name] = named_dims
+        if field_dimlists:
+            result[scope_name] = field_dimlists
 
     return result
-
-
-def _mapping_from_struct_metadata(dt: DataTree) -> dict[str, str]:
-    """
-    Locate the StructMetadata.0 variable (typically at /HDFEOS
-    INFORMATION), parse its ODL (Object Description Language) content
-    to extract every named dimension and its size, then match those
-    against the phony dims in the tree by size.
-
-    Returns an empty dict if no StructMetadata.0 is found or parsing
-    fails.
-    """
-    struct_text = _find_struct_metadata(dt)
-    if not struct_text:
-        return {}
-
-    swath_dims = _parse_odl_scope_dimensions(struct_text)
-    if not swath_dims:
-        return {}
-
-    mapping: dict[str, str] = {}
-
-    scope_roots = _find_scope_roots(dt)
-    if not scope_roots:
-        scope_roots = [dt]
-
-    for scope_root in scope_roots:
-        # extract the swath name from the path, e.g.
-        # "/HDFEOS/SWATHS/OMI Ground Pixel Corners UV-1" -> "OMI Ground Pixel Corners UV-1"
-        swath_name = scope_root.path.rstrip("/").split("/")[-1]
-        named_dims = swath_dims.get(swath_name)
-
-        if not named_dims:
-            # swath name not found in ODL
-            continue
-
-        size_to_names: dict[int, list[str]] = defaultdict(list)
-        for name, size in named_dims.items():
-            size_to_names[size].append(name)
-
-        scope_mapping = _match_phony_to_named(scope_root, size_to_names, named_dims)
-        mapping.update(scope_mapping)
-
-    return mapping
-
-
-def _match_phony_to_named(
-    dt: DataTree,
-    size_to_names: dict[int, list[str]],
-    named_dims: dict[str, int],
-) -> dict[str, str]:
-    """
-    For every phony dim in the tree, look up its size in ``size_to_names``.
-
-    - If only one real name has that size, the mapping is unambiguous.
-    - If multiple real names share the same size, we use the *position* of
-      the phony dim within its group's sorted dimension list to pick among
-      the candidates (ordered as they appear in the ODL block).
-    """
-    # ordered list of all named dims so we can use index as a tiebreaker
-    ordered_named = list(named_dims.keys())
-
-    mapping: dict[str, str] = {}
-
-    for node in dt.subtree:
-        ds = node.ds
-        if ds is None:
-            continue
-
-        # phony dims in this group sorted by their index (N in
-        # phony_dim_N)
-        local_phonies = sorted([d for d in ds.dims if _is_phony(d)], key=_phony_index)
-
-        for phony in local_phonies:
-            size = ds.dims[phony]
-            candidates = size_to_names.get(size, [])
-            if not candidates:
-                continue
-            if len(candidates) == 1:
-                mapping[phony] = candidates[0]
-            else:
-                # use the position of this phony dim among same-size dims in
-                # this group to index into the ordered candidate list.
-                same_size_in_group = [p for p in local_phonies if ds.dims[p] == size]
-                pos = same_size_in_group.index(phony)
-                # sort candidates by their order in the odl block
-                ordered_candidates = sorted(candidates, key=ordered_named.index)
-                if pos < len(ordered_candidates):
-                    mapping[phony] = ordered_candidates[pos]
-
-    return mapping
 
 
 def _apply_mapping(dt: DataTree, mapping: dict[str, str]) -> DataTree:
     """
     Walk the tree, apply rename_dims to every group dataset that contains
-    any of the phony dims in ``mapping``, then reconstruct the entire tree
+    any of the phony dims in mapping, then reconstruct the entire tree
     from a flat path -> dataset dict using DataTree.from_dict.
 
     This avoids any direct node copying and is the idiomatic way to rebuild
@@ -292,6 +187,66 @@ def _apply_mapping(dt: DataTree, mapping: dict[str, str]) -> DataTree:
         local_mapping = {k: v for k, v in mapping.items() if k in ds.dims}
         if local_mapping:
             ds = ds.rename_dims(local_mapping)
+
+        path_to_ds[node.path] = ds
+
+    return DataTree.from_dict(path_to_ds)
+
+
+def _find_scope_for_node(node: DataTree, scope_roots: list[DataTree]) -> str | None:
+    """
+    Return the scope name (last path component of the scope root) that this
+    node lives under, or None if the node is not under any known scope root.
+    """
+    for scope_root in scope_roots:
+        scope_path = scope_root.path.rstrip("/")
+        if node.path == scope_path or node.path.startswith(scope_path + "/"):
+            return scope_path.split("/")[-1]
+    return None
+
+
+def _apply_from_field_dimlists(
+    dt: DataTree,
+    scope_field_dimlists: dict[str, dict[str, list[str]]],
+) -> DataTree:
+    """
+    Walk every node in the tree. For each variable in the node, look up its
+    real dim names by scope name + variable name directly from the ODL field
+    dimlists, then rename only that variable's dims within that node.
+
+    This never builds a global phony to real mapping, so two variables with the
+    same name in different scopes are always resolved against their own scope's
+    DimList entries independently.
+    """
+    scope_roots = _find_scope_roots(dt)
+    path_to_ds: dict[str, xr.Dataset] = {}
+
+    for node in dt.subtree:
+        ds = node.ds if node.ds is not None else xr.Dataset()
+
+        scope_name = _find_scope_for_node(node, scope_roots)
+        field_dimlists = scope_field_dimlists.get(scope_name, {}) if scope_name else {}
+
+        if field_dimlists:
+            local_mapping: dict[str, str] = {}
+
+            for var_name, da in ds.items():
+                odl_dims = field_dimlists.get(var_name)
+                if odl_dims is None or len(odl_dims) != len(da.dims):
+                    continue
+                for current_dim, real_name in zip(da.dims, odl_dims):
+                    existing = local_mapping.get(current_dim)
+                    if existing is not None and existing != real_name:
+                        warnings.warn(
+                            f"Conflicting ODL DimList for {current_dim!r} in "
+                            f"{node.path!r}: {existing!r} vs {real_name!r}. "
+                            f"Keeping {existing!r}."
+                        )
+                    else:
+                        local_mapping[current_dim] = real_name
+
+            if local_mapping:
+                ds = ds.rename_dims(local_mapping)
 
         path_to_ds[node.path] = ds
 

--- a/tests/test_hdf_phony_dims.py
+++ b/tests/test_hdf_phony_dims.py
@@ -106,9 +106,16 @@ def test_struct_metadata_renames_dims():
         "END_GROUP=Dimension\n"
         "GROUP=DimensionMap\n"
         "END_GROUP=DimensionMap\n"
+        "GROUP=DataField\n"
+        "OBJECT=DataField_1\n"
+        'DataFieldName="ColumnAmount"\n'
+        'DimList=("nTimes","nXtrack")\n'
+        "END_OBJECT=DataField_1\n"
+        "END_GROUP=DataField\n"
         "END_GROUP=SWATH_1\n"
         "END_GROUP=SwathStructure\n"
     )
+
     struct_da = xr.DataArray(odl)
     da = xr.DataArray(
         [[1.0] * 60] * 1496,
@@ -143,6 +150,12 @@ def test_struct_metadata_renames_dims_multi_swath():
         "END_GROUP=Dimension\n"
         "GROUP=DimensionMap\n"
         "END_GROUP=DimensionMap\n"
+        "GROUP=DataField\n"
+        "OBJECT=DataField_1\n"
+        'DataFieldName="ColumnAmount"\n'
+        'DimList=("nTimes","nXtrack")\n'
+        "END_OBJECT=DataField_1\n"
+        "END_GROUP=DataField\n"
         "END_GROUP=SWATH_1\n"
         # start of swath 2
         "GROUP=SWATH_2\n"
@@ -158,6 +171,12 @@ def test_struct_metadata_renames_dims_multi_swath():
         "Size=30\n"
         "END_OBJECT=Dimension_2\n"
         "END_GROUP=Dimension\n"
+        "GROUP=DataField\n"
+        "OBJECT=DataField_1\n"
+        'DataFieldName="ColumnAmount2"\n'
+        'DimList=("nTimes","nXtrack")\n'
+        "END_OBJECT=DataField_1\n"
+        "END_GROUP=DataField\n"
         "END_GROUP=SWATH_2\n"
         "END_GROUP=SwathStructure\n"
     )
@@ -169,18 +188,18 @@ def test_struct_metadata_renames_dims_multi_swath():
 
     da2 = xr.DataArray(
         [[1.0] * 30] * 1496,
-        dims=[phony(0), phony(1)],
+        dims=[phony(2), phony(3)],
     )
     dt = make_tree(
         {
             "/HDFEOS INFORMATION": xr.Dataset({"StructMetadata.0": struct_da}),
             "/HDFEOS/SWATHS/MySWATH/Data Fields": xr.Dataset({"ColumnAmount": da}),
-            "/HDFEOS/SWATHS/MySWATH2/Data Fields": xr.Dataset({"ColumnAmount": da2}),
+            "/HDFEOS/SWATHS/MySWATH2/Data Fields": xr.Dataset({"ColumnAmount2": da2}),
         }
     )
     result = rename_phony_dims(dt)
     swath1_dims = result["/HDFEOS/SWATHS/MySWATH/Data Fields"].ds["ColumnAmount"].dims
-    swath2_dims = result["/HDFEOS/SWATHS/MySWATH2/Data Fields"].ds["ColumnAmount"].dims
+    swath2_dims = result["/HDFEOS/SWATHS/MySWATH2/Data Fields"].ds["ColumnAmount2"].dims
 
     # have the names been recovered?
     assert swath1_dims == ("nTimes", "nXtrack")
@@ -190,7 +209,7 @@ def test_struct_metadata_renames_dims_multi_swath():
         result["/HDFEOS/SWATHS/MySWATH/Data Fields"].ds["ColumnAmount"].shape
     )
     swath2_dim_shape = (
-        result["/HDFEOS/SWATHS/MySWATH2/Data Fields"].ds["ColumnAmount"].shape
+        result["/HDFEOS/SWATHS/MySWATH2/Data Fields"].ds["ColumnAmount2"].shape
     )
 
     # are dimensions in differnet swaths, with different sizes but
@@ -216,6 +235,12 @@ def test_struct_grid_metadata_renames_dims():
         "END_GROUP=Dimension\n"
         "GROUP=DimensionMap\n"
         "END_GROUP=DimensionMap\n"
+        "GROUP=DataField\n"
+        "OBJECT=DataField_1\n"
+        'DataFieldName="ColumnAmount"\n'
+        'DimList=("nTimes","nXtrack")\n'
+        "END_OBJECT=DataField_1\n"
+        "END_GROUP=DataField\n"
         "END_GROUP=GRID_1\n"
         "END_GROUP=GridStructure\n"
     )


### PR DESCRIPTION
Github Issue: #394

### Description

Updates ODL parser for HDFEOS data to apply full mapping based of DataField and GeoField groups within each Swath/Grid scope. The previous implementation relied on sized based matching from parsing just each scopes main Dimension group, but this is not robust enough after exhaustive testing against 114 collections in UAT. 

### Overview of work done

Implement more robust parsing per Swath/Grid scope and parse each scopes Data/GeoField directly, and recovering each variable dimension names from `DimList` object field instead of having it be size based matching. 


Example of HDFEOS `DataField` object specification
```
OBJECT=DataField_2
	DataFieldName="FoV75CornerLatitude"
	DataType=H5T_NATIVE_FLOAT
	DimList=("nCorners","nTimes","nXtrack")
	MaxdimList=("nCorners","nTimes","nXtrack")
	CompressionType=HE5_HDFE_COMP_SHUF_DEFLATE
	DeflateLevel=9
END_OBJECT=DataField_2
```

### Overview of verification done

Validated against OMCLDO2_003, OMCLODG_004, and OMCORPIX_003, OMDOAO3Z_003, OMDOAO3_003, GPM_2AGPROFF16SSMIS_08, GPM_2AGPROFNPPATMS_CLIM_07 (which should be a fairly representative subset of both HDF/HDFEOS files and the new GPM netcdf). Updated tests for the parser accordingly.

I have validated these changes work with 133 GES DISC HDF/EOS and the new GPM v08 collections with harmony-in-a-box

## PR checklist:

* [X] Linted
* [X] Updated unit tests
* [X] Updated changelog
* [X] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_