### PR TITLE
Fix/memory issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 ### Changed
-### Deprecated 
+### Deprecated
 ### Removed
 - Removed poetry as a dependency (should have poetry externally already)
 ### Fixed
+- [issue/405] (https://github.com/podaac/l2ss-py/issues/405) Chunk logic now handles data without dimensions in root node.
 ### Security
 
 
@@ -38,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [issue/364] (https://github.com/podaac/l2ss-py/issues/364) Implement vertical subsetting via dimensions.
 ### Changed
 - [issue/246] (https://github.com/podaac/l2ss-py/issues/246) Subsetting parameters part of history attributes and json history.
-### Deprecated 
+### Deprecated
 - [issue/358] (https://github.com/podaac/l2ss-py/issues/358) Update _convert_time_from_description to use nanosecond precision & time encoding to only specify dtype if units is also present
 ### Removed
 ### Fixed

--- a/podaac/subsetter/dimension_cleanup.py
+++ b/podaac/subsetter/dimension_cleanup.py
@@ -39,6 +39,17 @@ def remove_duplicate_dims_xarray(dataset: xr.Dataset) -> xr.Dataset:
     Handle datasets with duplicate dimensions in xarray while preserving
     encodings and handling multiple duplicate dimensions.
     """
+
+    has_duplicates = False
+    for var in dataset.variables.values():
+        dim_list = list(var.dims)
+        if len(dim_list) != len(set(dim_list)):
+            has_duplicates = True
+            break
+
+    if not has_duplicates:
+        return dataset
+
     # Work with a copy
     ds = dataset.copy(deep=True)
 

--- a/podaac/subsetter/subset.py
+++ b/podaac/subsetter/subset.py
@@ -414,7 +414,6 @@ def subset(
 
         # apply chunking after dimension name recovery (if needed)
         dataset = file_utils.chunk_datatree(dataset)
-        print(dataset)
 
         lat_var_names, lon_var_names, time_var_names = coordinate_utils.get_coordinate_variable_names(
             dataset=dataset, lat_var_names=lat_var_names, lon_var_names=lon_var_names, time_var_names=time_var_names

--- a/podaac/subsetter/subset.py
+++ b/podaac/subsetter/subset.py
@@ -412,6 +412,10 @@ def subset(
         if hdf_type:
             dataset = hdf_utils.rename_phony_dims(dataset)
 
+        # apply chunking after dimension name recovery (if needed)
+        dataset = file_utils.chunk_datatree(dataset)
+        print(dataset)
+
         lat_var_names, lon_var_names, time_var_names = coordinate_utils.get_coordinate_variable_names(
             dataset=dataset, lat_var_names=lat_var_names, lon_var_names=lon_var_names, time_var_names=time_var_names
         )
@@ -436,10 +440,7 @@ def subset(
         if hdf_type and (min_time or max_time):
             dataset, _ = tree_time_converting.convert_to_datetime(dataset, time_var_names, hdf_type)
 
-        chunks = file_utils.calculate_chunks(dataset)
         all_vars = variables_utils.get_all_variable_names_from_dtree(dataset)
-        if chunks:
-            dataset = dataset.chunk(chunks)
         if variables:
             # Drop variables that aren't explicitly requested, except lat_var_name and
             # lon_var_name which are needed for subsetting

--- a/podaac/subsetter/tree_time_converting.py
+++ b/podaac/subsetter/tree_time_converting.py
@@ -123,7 +123,6 @@ def convert_to_datetime(
         group, var_name = get_group_by_path(data_tree, var_path)
 
         if np.issubdtype(group[var_name].dtype, np.dtype(float)) or np.issubdtype(group[var_name].dtype, np.float32):
-
             # adjust the time values from the start date
             if start_date:
                 # create array of the start time in datetime format
@@ -131,9 +130,7 @@ def convert_to_datetime(
                 # add seconds since the start time to the start time to get the time at the data point
                 new_values = date_time_array.astype("datetime64[ns]") + group[var_name].astype("timedelta64[s]").values
                 try:
-                    group[var_name].values = (
-                        date_time_array.astype("datetime64[ns]") + group[var_name].astype("timedelta64[s]").values
-                    )
+                    group[var_name].values = new_values
                 except ValueError:
                     pass
                 update_coord_everywhere(data_tree, var_name, new_values)

--- a/podaac/subsetter/utils/file_utils.py
+++ b/podaac/subsetter/utils/file_utils.py
@@ -6,6 +6,8 @@ file_utils.py
 Utility functions for file and dataset handling.
 """
 
+from collections.abc import Hashable, Mapping
+
 import cftime
 import dateutil
 import xarray as xr
@@ -14,16 +16,50 @@ from dateutil import parser
 from xarray import DataTree
 
 
-def calculate_chunks(dataset: xr.Dataset) -> dict:
+def chunk_datatree(datatree: xr.DataTree) -> xr.DataTree:
     """
-    For the given dataset, calculate if the size on any dimension is
+    Walk every node in the datatree and chunk each node's dataset
+    independently based on logic present in `calculate_chunks`.
+
+    For HDFEOS files the root and all intermediate group nodes carry
+    no dimensions or data variables. Chunking must be applied at the
+    leaf nodes where the actual data and dimensions live, e.g.
+    /HDFEOS/GRIDS/OMI Column Amount O3/Data Fields.
+
+    Parameters
+    ----------
+    datatree : xr.DataTree
+        The datatree to chunk in place.
+
+    Returns
+    -------
+    xr.DataTree
+        The same datatree with all data-carrying nodes chunked.
+    """
+    for node in datatree.subtree:
+        # skip intermediate group nodes that carry no data variables
+        # or dimensions. these are structural nodes only.
+        if not node.ds or not node.ds.data_vars or not node.ds.dims:
+            continue
+
+        chunks = calculate_chunks(node)
+        if chunks:
+            # overide node chunks directly
+            node.ds = node.ds.chunk(chunks)
+
+    return datatree
+
+
+def calculate_chunks(node: xr.DataTree | xr.Dataset) -> Mapping[Hashable, int]:
+    """
+    For the given datatree node, calculate if the size on any dimension is
     worth chunking. Any dimension larger than 4000 will be chunked. This
     is done to ensure that the variable can fit in memory.
     """
-    if len(dataset.dims) <= 3:
-        chunk = {dim: 4000 for dim in dataset.dims if dataset.sizes[dim] > 4000 and len(dataset.dims) > 1}
+    if len(node.dims) <= 3:
+        chunk = {dim: 4000 for dim in node.dims if node.sizes[dim] > 4000 and len(node.dims) > 1}
     else:
-        chunk = {dim: 500 for dim in dataset.dims if dataset.sizes[dim] > 500}
+        chunk = {dim: 500 for dim in node.dims if node.sizes[dim] > 500}
     return chunk
 
 

--- a/tests/test_chunk.py
+++ b/tests/test_chunk.py
@@ -1,0 +1,52 @@
+import numpy as np
+import pytest
+import xarray as xr
+from podaac.subsetter.utils.file_utils import calculate_chunks, chunk_datatree
+
+
+@pytest.fixture
+def small_dataset() -> xr.Dataset:
+    return xr.Dataset({"var": (["x", "y"], np.zeros((100, 100)))})
+
+
+@pytest.fixture
+def large_dataset() -> xr.Dataset:
+    return xr.Dataset({"var": (["x", "y"], np.zeros((5000, 5000)))})
+
+
+def test_calculate_chunks_returns_empty_for_small_dims(small_dataset: xr.Dataset) -> None:
+    # a small enough dataset is not chunked
+    result = calculate_chunks(small_dataset)
+    assert result == {}
+
+
+def test_calculate_chunks_returns_chunks_for_large_dims(large_dataset: xr.Dataset) -> None:
+    result = calculate_chunks(large_dataset)
+    assert result == {"x": 4000, "y": 4000}
+
+
+def test_chunk_datatree_chunks_leaf_nodes(large_dataset: xr.Dataset) -> None:
+    tree = xr.DataTree.from_dict({"/data": large_dataset})
+    result = chunk_datatree(tree)
+    chunks = result["/data"].ds["var"].chunks
+    assert chunks is not None
+    assert chunks[0] == (4000, 1000)  # 5000 split into 4000 + 1000
+    assert chunks[1] == (4000, 1000)
+
+
+def test_chunk_datatree_skips_empty_nodes(small_dataset: xr.Dataset) -> None:
+    tree = xr.DataTree.from_dict({"/": None, "/data": small_dataset})
+    result = chunk_datatree(tree)
+    assert result["/data"].ds["var"].chunks is None
+
+
+def test_chunk_datatree_skips_root_with_no_dims(large_dataset: xr.Dataset) -> None:
+    tree = xr.DataTree.from_dict({"/": xr.Dataset(), "/leaf": large_dataset})
+
+    # given a node with no dims, the the chunk calculation should return an empty dict
+    assert calculate_chunks(tree.root) == {}
+
+    # but when applying chunk_datatree, child nodes should get chunked
+    result = chunk_datatree(tree)
+    assert result["/leaf"].ds["var"].chunks is not None
+    assert result["/"].ds.sizes == {}

--- a/tests/test_subset_illegal_name_recovery.py
+++ b/tests/test_subset_illegal_name_recovery.py
@@ -1,7 +1,7 @@
-import numpy as np
-import pytest
 from unittest.mock import Mock
 
+import numpy as np
+import pytest
 from podaac.subsetter import subset
 
 
@@ -41,8 +41,10 @@ def _patch_subset_dependencies(monkeypatch, subsetted_dataset, spatial_bounds):
     monkeypatch.setattr(subset.xr, "open_datatree", lambda *_args, **_kwargs: _DummyOpenDataTree(dummy_tree))
     monkeypatch.setattr(subset.file_utils, "override_decode_cf_datetime", lambda: None)
     monkeypatch.setattr(subset.file_utils, "has_scantime", lambda *_args, **_kwargs: False)
-    monkeypatch.setattr(subset.coordinate_utils, "get_coordinate_variable_names", lambda **_kwargs: (["/lat"], ["/lon"], []))
-    monkeypatch.setattr(subset.file_utils, "calculate_chunks", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        subset.coordinate_utils, "get_coordinate_variable_names", lambda **_kwargs: (["/lat"], ["/lon"], [])
+    )
+    monkeypatch.setattr(subset.file_utils, "chunk_datatree", lambda dt: dt)
     monkeypatch.setattr(subset.variables_utils, "get_all_variable_names_from_dtree", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(
         subset.variables_utils, "normalize_candidate_paths_against_dtree", lambda paths, *_args, **_kwargs: paths
@@ -52,9 +54,7 @@ def _patch_subset_dependencies(monkeypatch, subsetted_dataset, spatial_bounds):
     monkeypatch.setattr(subset.metadata_utils, "set_json_history", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(subset.datatree_subset, "clean_inherited_coords", lambda ds: ds)
     monkeypatch.setattr(subset.datatree_subset, "prepare_basic_encoding", lambda *_args, **_kwargs: {})
-    monkeypatch.setattr(
-        subset.datatree_subset, "tree_get_spatial_bounds", lambda *_args, **_kwargs: spatial_bounds
-    )
+    monkeypatch.setattr(subset.datatree_subset, "tree_get_spatial_bounds", lambda *_args, **_kwargs: spatial_bounds)
     monkeypatch.setattr(subset.metadata_utils, "update_netcdf_attrs", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(subset.metadata_utils, "ensure_time_units", lambda *_args, **_kwargs: None)
 


### PR DESCRIPTION
Github Issue: #405 

### Description

A handful of collections were failing in harmony for exceeding memory limits in the case of all variable subsets.

```
GPM_2BCMB_07
OMAEROG_003
OMAERO_003
OMCLDO2Z_003
OMCLDO2_003
OMTO3G_003
OMTO3G_004
```

### Overview of work done

The logic to calculate chunks and then coerce data to dasked backed arrays only ever considered the root node of a datatree. In the case where the root node had no dims, but child nodes did, this would cause the data to never be chunked to fit into memory. This would result in the data continuing to be backed by numpy arrays through out the remainder of the program resulting in a lot of deep copies of the data being made. 

The logic for calculating and chunks and coercing data to Dask backed arrays was updated to consider all nodes in a tree. A couple of redundant calculations and a guard for checking if duplicates are present before making deep copies of the arrays were also added. 

### Overview of verification done

Validation was performed with local harmony instance for stated collections with same memory limit as in prod/uat. 

### Overview of integration done

See above

## PR checklist:

* [X] Linted
* [X] Updated unit tests
* [X] Updated changelog
* [X] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_