### PR TITLE
optimize update_dataset_with_time performance with dask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed poetry as a dependency (should have poetry externally already)
 ### Fixed
 - [issue/405] (https://github.com/podaac/l2ss-py/issues/405) Chunk logic now handles data without dimensions in root node.
+- Optimize performance of ScanTime variable computation
 ### Security
 - Updated dependency libraries
 

--- a/podaac/subsetter/datatree_subset.py
+++ b/podaac/subsetter/datatree_subset.py
@@ -1,14 +1,14 @@
 """script to help with subsetting xarray datatree objects"""
 
 # pylint: disable=inconsistent-return-statements
-import datetime
 import logging
 import re
+from typing import Literal
 
 import cf_xarray as cfxr
 import numpy as np
+import pandas as pd
 import xarray as xr
-from netCDF4 import date2num  # pylint: disable=no-name-in-module
 from xarray import DataTree
 
 from podaac.subsetter import dimension_cleanup as dc
@@ -1004,45 +1004,122 @@ def clean_inherited_coords(dt: DataTree) -> DataTree:
     return dt
 
 
-def update_dataset_with_time(og_ds, time_name="timeMidScan", group_path=None):
+# lookup table for nanoseconds per unit, used to convert timedelta64 fields to integers.
+_NS_PER_UNIT_LOOKUP: dict[str, float] = {
+    "day": 24.0 * 60.0 * 60.0 * 1e9,
+    "hour": 60.0 * 60.0 * 1e9,
+    "minute": 60.0 * 1e9,
+}
+
+
+def _coerce_to_int_array(
+    data_array: xr.DataTree,
+    unit_type: Literal["day", "hour", "minute"],
+) -> np.ndarray:
+    """
+    Return the underlying array as int32, converting timedelta64 if necessary.
+
+    Parameters
+    ----------
+    data_array : xr.DataArray
+        Source DataArray, possibly (probably) backed by dask.
+    unit_type : Literal["day", "hour", "minute"]
+        Used only when the underlying dtype is ``timedelta64``.
+
+    Returns
+    -------
+    np.ndarray
+        1-D (or N-D) int32 NumPy array.
+    """
+    # .values triggers a single dask compute for the whole array.
+    arr: np.ndarray = data_array.values
+    if np.issubdtype(arr.dtype, np.timedelta64):
+        return (arr.astype("int64") / _NS_PER_UNIT_LOOKUP[unit_type]).astype(np.int32)
+    return arr.astype(np.int32)
+
+
+def update_dataset_with_time(
+    og_ds: xr.Dataset,
+    time_name: str = "timeMidScan",
+    group_path: str | None = None,
+) -> xr.Dataset:
     """
     Compute a time variable if not present, using values from the dataset.
+
+    performs a single vectorized pass via pandas.to_datetime, which
+    ensures Dask-backed arrays are materialised exactly once.
+
+    Parameters
+    ----------
+    og_ds : xr.Dataset
+        Input dataset, potentially containing Dask-backed arrays.
+    time_name : str, optional
+        Name to assign to the output numeric time variable.
+        Defaults to "timeMidScan".
+    group_path : str or None, optional
+        Group path string; time construction is only applied when this
+        contains "ScanTime".
+
+    Returns
+    -------
+    xr.Dataset
+        Shallow copy of the input dataset with ``time_name`` and
+        ``time_name + "_datetime"`` variables added when applicable.
+
+    Raises
+    ------
+    ValueError
+        If any MilliSecond value is outside ``[0, 1000)``.
     """
-    ds = og_ds.copy()
+    ds: xr.Dataset = og_ds.copy(deep=False)
 
-    def convert_to_int(value, unit_type):
-        if isinstance(value, np.timedelta64):
-            ns_per_unit = {"day": 24 * 60 * 60 * 1e9, "hour": 60 * 60 * 1e9, "minute": 60 * 1e9}
-            return int(value.astype("int64") / ns_per_unit[unit_type])
-        return int(value)
+    if any(time_name in var for var in ds.variables):
+        return ds
 
-    if not any(time_name in var for var in ds.variables):
-        if "ScanTime" in (group_path or ""):
-            time_unit_out = "seconds since 1980-01-06 00:00:00"
-            new_time_list = []
-            new_time_list_dt = []
+    if "ScanTime" not in (group_path or ""):
+        return ds
 
-            for i, _ in enumerate(ds["Year"].values):
-                ms = int(ds["MilliSecond"].values[i])
-                if not 0 <= ms < 1000:
-                    raise ValueError(f"Milliseconds out of range: {ms} at index {i}")
-                microsecond = ms * 1000
-                dt = datetime.datetime(
-                    int(ds["Year"].values[i]),
-                    int(ds["Month"].values[i]),
-                    convert_to_int(ds["DayOfMonth"].values[i], "day"),
-                    hour=convert_to_int(ds["Hour"].values[i], "hour"),
-                    minute=convert_to_int(ds["Minute"].values[i], "minute"),
-                    second=int(ds["Second"].values[i]),
-                    microsecond=microsecond,
-                )
-                new_time_list.append(date2num(dt, time_unit_out))
-                new_time_list_dt.append(dt)  # keep actual datetime
+    # validate milliseconds first
+    ms_arr = ds["MilliSecond"].values.astype(np.int32)
+    invalid_mask = (ms_arr < 0) | (ms_arr >= 1000)
+    if invalid_mask.any():
+        first_bad: int = int(np.argmax(invalid_mask))
+        raise ValueError(f"Milliseconds out of range: {ms_arr[first_bad]} at index {first_bad}")
 
-            ds[time_name] = (ds["Year"].dims, np.array(new_time_list))
-            ds[time_name].attrs["unit"] = time_unit_out
+    # materialise each variable array once, coercing where needed
+    years = ds["Year"].values.astype(np.int32)
+    months = ds["Month"].values.astype(np.int32)
+    days = _coerce_to_int_array(ds["DayOfMonth"], "day")
+    hours = _coerce_to_int_array(ds["Hour"], "hour")
+    minutes = _coerce_to_int_array(ds["Minute"], "minute")
+    seconds = ds["Second"].values.astype(np.int32)
 
-            ds[time_name + "_datetime"] = (ds["Year"].dims, np.array(new_time_list_dt))
+    # build out the new datetime array
+    # note(ocs): could also do pure numpy approach, but pandas is
+    # easier and already dep.
+    dt_ns: np.ndarray = pd.to_datetime(
+        pd.DataFrame(
+            {
+                "year": years,
+                "month": months,
+                "day": days,
+                "hour": hours,
+                "minute": minutes,
+                "second": seconds,
+                "microsecond": ms_arr * 1000,
+            }
+        )
+    ).to_numpy(dtype="datetime64[ns]")
+
+    # convert to seconds since GPS epoch
+    time_unit_out: str = "seconds since 1980-01-06 00:00:00"
+    epoch_ns = np.datetime64("1980-01-06T00:00:00", "ns")
+    time_seconds: np.ndarray = ((dt_ns - epoch_ns).astype(np.int64) / 1e9).astype(np.float64)
+
+    dims = ds["Year"].dims
+    ds[time_name] = (dims, time_seconds)
+    ds[time_name].attrs["unit"] = time_unit_out
+    ds[time_name + "_datetime"] = (dims, dt_ns)
 
     return ds
 

--- a/podaac/subsetter/datatree_subset.py
+++ b/podaac/subsetter/datatree_subset.py
@@ -1013,7 +1013,7 @@ _NS_PER_UNIT_LOOKUP: dict[str, float] = {
 
 
 def _coerce_to_int_array(
-    data_array: xr.DataTree,
+    data: xr.DataSet | xr.DataArray,
     unit_type: Literal["day", "hour", "minute"],
 ) -> np.ndarray:
     """
@@ -1032,7 +1032,7 @@ def _coerce_to_int_array(
         1-D (or N-D) int32 NumPy array.
     """
     # .values triggers a single dask compute for the whole array.
-    arr: np.ndarray = data_array.values
+    arr: np.ndarray = data.values
     if np.issubdtype(arr.dtype, np.timedelta64):
         return (arr.astype("int64") / _NS_PER_UNIT_LOOKUP[unit_type]).astype(np.int32)
     return arr.astype(np.int32)


### PR DESCRIPTION
Github Issue: NA

### Description

TLDR: creation of scan time variable taking 2.5 minutes, optimized method computes it in 0.015 seconds.

#428 updated the chunking logic to ensure that chunking/conversion to dask backed arrays was applied for large arrays across all tree nodes, and not just the root node. A side affect of this is that the loop for computing the ScanTime temporal variable for GPM collections is significantly slower because calling `.values` on the dask backed arrays forces dask to rematerialize the array every single iteration. So for dataset where the year array has 7925 elements, the arrays for "Milliseconds, "Second", "Minute", "Hour", "DayOfMonth", "Month", and "Year" will be rematerialized 7925 times each, resulting in 55,475 calls to `.values`. With dask arrays this takes **~2.5 minutes** to compute the new ScanTime variable. While this computation was much faster (1.497 seconds) with just numpy backed arrays, for memory purposes it's still better to keep them as dask backed arrays. 

This PR refactors the `update_dataset_with_time` method to be vectorized and only ever materialize each needed array once. The run time is **0.015 seconds** on the same dataset from the first paragraph. So still faster than even if we kept the dataset backed by numpy arrays.

Below are the cProfile results comparing the original function to the new optimized function.

```
Opening 2A.GPM.Ku.V9-20211125.20140308-S220950-E234217.000144.V07A.HDF5

=== original ===
         235417899 function calls (228385465 primitive calls) in 138.338 seconds

   Ordered by: cumulative time
   List reduced from 2459 to 20 due to restriction <20>

   ncalls    tottime  percall  cumtime  percall filename:lineno(function)
      2/1      0.434    0.217  138.106  138.106 /Users/ocsmith/Developer/dev/l2ss/l2ss-py/./tp.py:17(update_dataset_with_time_og)
55477/55476    0.043    0.000  136.750    0.002 /Users/ocsmith/Developer/dev/l2ss/l2ss-py/.venv/lib/python3.13/site-packages/xarray/core/dataarray.py:801(values)
55477/55476    0.030    0.000  136.700    0.002 /Users/ocsmith/Developer/dev/l2ss/l2ss-py/.venv/lib/python3.13/site-packages/xarray/core/variable.py:562(values)
55477/55476    0.037    0.000  136.669    0.002 /Users/ocsmith/Developer/dev/l2ss/l2ss-py/.venv/lib/python3.13/site-packages/xarray/core/variable.py:348(_as_array_or_item)
966877/55486   0.853    0.000  136.633    0.002 {built-in method numpy.asarray}
55477/55476    0.059    0.000  136.545    0.002 /Users/ocsmith/Developer/dev/l2ss/l2ss-py/.venv/lib/python3.13/site-packages/dask/array/core.py:1706(__array__)
55477/55476    0.210    0.000  136.470    0.002 /Users/ocsmith/Developer/dev/l2ss/l2ss-py/.venv/lib/python3.13/site-packages/dask/base.py:353(compute)
55477/55476    0.419    0.000  136.260    0.002 /Users/ocsmith/Developer/dev/l2ss/l2ss-py/.venv/lib/python3.13/site-packages/dask/base.py:601(compute)
   166428      0.147    0.000  101.740    0.001 /Users/ocsmith/Developer/dev/l2ss/l2ss-py/.venv/lib/python3.13/site-packages/dask/local.py:140(queue_get)
   166428      0.428    0.000   99.420    0.001 /Users/ocsmith/anaconda3/envs/dev-utils/lib/python3.13/queue.py:177(get)
55477/55476    0.404    0.000   98.248    0.002 /Users/ocsmith/Developer/dev/l2ss/l2ss-py/.venv/lib/python3.13/site-packages/dask/threaded.py:62(get)
   166321      0.784    0.000   98.114    0.001 /Users/ocsmith/anaconda3/envs/dev-utils/lib/python3.13/threading.py:327(wait)
55477/55476    0.947    0.000   97.469    0.002 /Users/ocsmith/Developer/dev/l2ss/l2ss-py/.venv/lib/python3.13/site-packages/dask/local.py:382(get_async)
166428/110982  0.208    0.000   65.954    0.001 /Users/ocsmith/anaconda3/envs/dev-utils/lib/python3.13/concurrent/futures/thread.py:54(run)
388332/221934  0.835    0.000   64.546    0.000 /Users/ocsmith/Developer/dev/l2ss/l2ss-py/.venv/lib/python3.13/site-packages/dask/_task_spec.py:753(__call__)
166428/110982  0.110    0.000   64.406    0.001 {method 'run' of '_contextvars.Context' objects}
166428/110982  0.188    0.000   64.345    0.001 /Users/ocsmith/Developer/dev/l2ss/l2ss-py/.venv/lib/python3.13/site-packages/dask/local.py:266(batch_execute_tasks)
166428/110982  0.361    0.000   64.260    0.001 /Users/ocsmith/Developer/dev/l2ss/l2ss-py/.venv/lib/python3.13/site-packages/dask/local.py:246(execute_task)
110952/55506   0.280    0.000   60.261    0.001 /Users/ocsmith/Developer/dev/l2ss/l2ss-py/.venv/lib/python3.13/site-packages/dask/array/core.py:121(getter)
110952/55506   0.195    0.000   56.475    0.001 /Users/ocsmith/Developer/dev/l2ss/l2ss-py/.venv/lib/python3.13/site-packages/xarray/core/indexing.py:569(__array__)




=== optimized ===
         43373 function calls (41994 primitive calls) in 0.028 seconds

   Ordered by: cumulative time
   List reduced from 978 to 20 due to restriction <20>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    0.028    0.028 /Users/ocsmith/Developer/dev/l2ss/l2ss-py/./tp.py:98(update_dataset_with_time)
   147/30    0.000    0.000    0.020    0.001 {built-in method numpy.asarray}
        7    0.000    0.000    0.020    0.003 /Users/ocsmith/Developer/dev/l2ss/l2ss-py/.venv/lib/python3.13/site-packages/xarray/core/dataarray.py:801(values)
        7    0.000    0.000    0.020    0.003 /Users/ocsmith/Developer/dev/l2ss/l2ss-py/.venv/lib/python3.13/site-packages/xarray/core/variable.py:562(values)
        7    0.000    0.000    0.020    0.003 /Users/ocsmith/Developer/dev/l2ss/l2ss-py/.venv/lib/python3.13/site-packages/xarray/core/variable.py:348(_as_array_or_item)
        7    0.000    0.000    0.020    0.003 /Users/ocsmith/Developer/dev/l2ss/l2ss-py/.venv/lib/python3.13/site-packages/dask/array/core.py:1706(__array__)
        7    0.000    0.000    0.020    0.003 /Users/ocsmith/Developer/dev/l2ss/l2ss-py/.venv/lib/python3.13/site-packages/dask/base.py:353(compute)
        7    0.000    0.000    0.020    0.003 /Users/ocsmith/Developer/dev/l2ss/l2ss-py/.venv/lib/python3.13/site-packages/dask/base.py:601(compute)
       21    0.000    0.000    0.017    0.001 /Users/ocsmith/Developer/dev/l2ss/l2ss-py/.venv/lib/python3.13/site-packages/dask/local.py:140(queue_get)
       21    0.000    0.000    0.016    0.001 /Users/ocsmith/anaconda3/envs/dev-utils/lib/python3.13/queue.py:177(get)
       21    0.000    0.000    0.016    0.001 /Users/ocsmith/anaconda3/envs/dev-utils/lib/python3.13/threading.py:327(wait)
        7    0.000    0.000    0.015    0.002 /Users/ocsmith/Developer/dev/l2ss/l2ss-py/.venv/lib/python3.13/site-packages/dask/threaded.py:62(get)
        7    0.000    0.000    0.015    0.002 /Users/ocsmith/Developer/dev/l2ss/l2ss-py/.venv/lib/python3.13/site-packages/dask/local.py:382(get_async)
    21/14    0.000    0.000    0.010    0.001 /Users/ocsmith/anaconda3/envs/dev-utils/lib/python3.13/concurrent/futures/thread.py:54(run)
    49/28    0.000    0.000    0.010    0.000 /Users/ocsmith/Developer/dev/l2ss/l2ss-py/.venv/lib/python3.13/site-packages/dask/_task_spec.py:753(__call__)
    21/14    0.000    0.000    0.010    0.001 {method 'run' of '_contextvars.Context' objects}
    21/14    0.000    0.000    0.010    0.001 /Users/ocsmith/Developer/dev/l2ss/l2ss-py/.venv/lib/python3.13/site-packages/dask/local.py:266(batch_execute_tasks)
    21/14    0.000    0.000    0.010    0.001 /Users/ocsmith/Developer/dev/l2ss/l2ss-py/.venv/lib/python3.13/site-packages/dask/local.py:246(execute_task)
     14/7    0.000    0.000    0.010    0.001 /Users/ocsmith/Developer/dev/l2ss/l2ss-py/.venv/lib/python3.13/site-packages/dask/array/core.py:121(getter)
        3    0.000    0.000    0.009    0.003 /Users/ocsmith/Developer/dev/l2ss/l2ss-py/./tp.py:72(_coerce_to_int_array)


```


### Overview of verification done

Tests performed on GPM_2AKu_07 (https://data.gesdisc.earthdata.nasa.gov/data/GPM_L2/GPM_2AKu.07/2014/067/2A.GPM.Ku.V9-20211125.20140308-S220950-E234217.000144.V07A.HDF5)

## PR checklist:

* [X] Linted
* [NA] Updated unit tests
* [X] Updated changelog
* [NA] Integration testing

_See [Pull Request Review Checklist](../CONTRIBUTING.md#reviewing) for pointers on reviewing this pull request_